### PR TITLE
Novo comando e alteracao em nome do comando

### DIFF
--- a/commands/admin/grupo.js
+++ b/commands/admin/grupo.js
@@ -1,0 +1,72 @@
+const { donos } = require("../../database/models/donos");
+
+module.exports = {
+  name: "grupo",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
+    
+    async function sendHelp() {
+      await sock.sendMessage(from, {text: `*Como mudar estados de um grupo com a Yuki:*
+> Ao usar /grupo deve-se usar um parâmetro de algum estado que deseja pôr no grupo.
+*Tipos de estado:*
+*"/grupo a"*
+> Deixa o grupo aberto para mensagens.
+*"/grupo f"*
+> Deixa o grupo fechado para membros.
+
+Fácil de usar, né? Não? Então você possui algum tipo de deficiência mental.`}, {quoted: msg});
+    }
+    try {
+      
+      const metadata = await sock.groupMetadata(from);
+      
+      const admin = metadata.participants.filter(p => p.admin).map(p => p.id);
+      
+      const sender = msg.key.participant
+      
+      const donoSender = await donos.findOne({userLid: sender});
+      
+      if(!admin.includes(sender) && !donoSender) {
+        await sock.sendMessage(from, {text: "Tu é admin? Seu merda."}, {quoted: msg});
+        return
+      }
+      
+      const parametro = args?.[0]?.trim();
+      
+      if(!parametro) {
+        await sendHelp();
+        return
+      }
+      
+      if(parametro === "f") {
+        await sock.groupSettingUpdate(from, 'announcement');
+        return
+       }
+      
+      if(parametro === "a") {
+        await sock.groupSettingUpdate(from, "not_announcement");
+        return
+      }
+      
+      else {
+        await sendHelp();
+        return
+      }
+      
+    }
+    catch(err) {
+      const debug = String(err);
+      
+      if(debug.includes("forbidden")) {
+        await sock.sendMessage(from, {text: "Não possuo admin."}, {quoted: msg});
+      }
+      
+      await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
+      
+      console.error(err)
+      
+    }
+    
+    
+  }
+  
+}

--- a/commands/fun/beijo.js
+++ b/commands/fun/beijo.js
@@ -27,7 +27,7 @@ module.exports = {
       
       const gifsRandom = gifs[Math.floor(Math.random() * gifs.length)];
       
-      const rpgList = [`@${sender.split("@")[0]} beijou @${mention.split("@")[0]} sem avisar nada... Criminoso porém estiloso`, `@${sender.split("@")[0]} deu um beijo em @${mention.split("@")[0]} qe travou o universo...`, `@${sender.split("@")[0]} tentou beijar @${mention.split("@")[0]} e levou um tapa que doeu até o vento...`, `@${sender.split("@")[0]} tentou beijar @${mention.split("@")[0]} e caiu de cara no chãoKKKKKKKK`, `@${sender.split("@")[0]} é... ${mention.split("@")[0]} saiu correndo, acho que foi um amor não correspondido`];
+      const rpgList = [`@${sender.split("@")[0]} beijou @${mention.split("@")[0]} sem avisar nada... Criminoso porém estiloso`, `@${sender.split("@")[0]} deu um beijo em @${mention.split("@")[0]} qe travou o universo...`, `@${sender.split("@")[0]} tentou beijar @${mention.split("@")[0]} e levou um tapa que doeu até o vento...`, `@${sender.split("@")[0]} tentou beijar @${mention.split("@")[0]} e caiu de cara no chãoKKKKKKKK`, `@${sender.split("@")[0]} é... @${mention.split("@")[0]} saiu correndo, acho que foi um amor não correspondido`];
       
       const RpgRandom = rpgList[Math.floor(Math.random() * rpgList.length)];
       

--- a/commands/geral/meulid.js
+++ b/commands/geral/meulid.js
@@ -4,6 +4,17 @@ module.exports = {
 
   async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
     try {
+      
+      const mention = msg.message?.textExtendedMessage?.contextInfo?.mentionedJid[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
+      
+      
+      if(mention) {
+        
+        await sock.sendMessage(from, {text: `O lid de @${mention.split("@")[0]} é: ${mention}`, mentions: [mention]}, {quoted: msg});
+        return
+      }
+      
+      
       const rawSender = msg.key.participant || msg.key.remoteJid;
 
       await sock.sendMessage(

--- a/commands/geral/sticker.js
+++ b/commands/geral/sticker.js
@@ -88,7 +88,7 @@ const directMedia =
     return;
   }
 
-  const fileName = `../../assets/temp/${Date.now()}`;
+  const fileName = path.join(__dirname, `../../assets/temp/${Date.now()}`);
   const inputPath = `${fileName}.jpg`;
   const outputPath = `${fileName}.webp`;
 

--- a/commands/grupo/grupoInfo.js
+++ b/commands/grupo/grupoInfo.js
@@ -3,7 +3,7 @@ const { grupos } = require("../../database/models/grupos");
 
 
 module.exports = {
-  name: "grupo",
+  name: "grupoinfo",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
     
     try {

--- a/config.js
+++ b/config.js
@@ -4,7 +4,7 @@ const prefixo = process.env.PREFIXO
 
 const botName = "Yuki"
 
-const version = "3.7.4"
+const version = "4.1.3"
 
 const numberOwner = "188123996786820@lid"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yukiv3",
-  "version": "3.7.4",
+  "version": "4.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
O nome do comando /grupo que servia para buscar informações do grupo, foi alterado para /grupoinfo, e no lugar de /grupo, veio um comando que muda os estados de um grupo

exemplo: /grupo a
//abre um grupo e deixa as mensagens ativas pra membros.