### PR TITLE
fix: normalizar userLid e consolidar duplicados no Mongo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -792,6 +792,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1120,6 +1121,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1214,6 +1216,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2767,6 +2770,19 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3011,6 +3027,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -3239,6 +3256,49 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -3674,6 +3734,7 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -3825,6 +3886,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
       "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }

--- a/src/commands/api/play.js
+++ b/src/commands/api/play.js
@@ -1,9 +1,10 @@
 const axios = require("axios");
 const { users } = require("../../database/models/users");
+const { normalizeUserLid } = require("../../utils/normalizeUserLid");
 
 module.exports = {
   name: "play",
-  async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     
     const texto = args.slice(0).join(" ")?.trim();
       try {
@@ -56,7 +57,7 @@ module.exports = {
     
     await sock.sendPresenceUpdate("paused", from);
     
-    await users.updateOne({userLid: msg.key.participant}, {$inc: {donwloads: 1}});
+    await users.updateOne({userLid: normalizeUserLid(sender)}, {$inc: {donwloads: 1}});
     
     
   }

--- a/src/commands/economia/description.js
+++ b/src/commands/economia/description.js
@@ -1,4 +1,5 @@
 const { users } = require("../../database/models/users");
+const { normalizeUserLid } = require("../../utils/normalizeUserLid");
 
 
 module.exports = {
@@ -8,8 +9,10 @@ module.exports = {
       
       
       
-      if(!await users.findOne({userLid: sender})) {
-        await users.create({userLid: msg.key.participant || msg.key.remoteJid, name: msg.pushName || "Sem nome"});
+      const normalizedSender = normalizeUserLid(sender);
+
+      if(!await users.findOne({userLid: normalizedSender})) {
+        await users.create({userLid: normalizedSender, name: msg.pushName || "Sem nome"});
       }
       
       const bioText = args?.join(" ")?.trim();
@@ -21,7 +24,7 @@ module.exports = {
       
       await sock.sendMessage(from, {text: "Mudando bio..."}, {quoted: msg});
       
-      await users.updateOne({userLid: sender}, {$set: {bio: bioText}});
+      await users.updateOne({userLid: normalizedSender}, {$set: {bio: bioText}});
       
       await sock.sendMessage(from, {text: `Bio mudada para: "${bioText}", use /perfil para ver alterações.`}, {quoted: msg});
     }

--- a/src/commands/economia/saldo.js
+++ b/src/commands/economia/saldo.js
@@ -1,4 +1,5 @@
 const { users } = require("../../database/models/users");
+const { normalizeUserLid } = require("../../utils/normalizeUserLid");
 
 module.exports = {
   name: "saldo",
@@ -6,11 +7,7 @@ module.exports = {
     try {
       await sock.sendMessage(from, { text: espera_pronta }, { quoted: msg });
 
-      let senderLid = sender?.split(":")[0];
-
-      if (!senderLid.includes("@")) {
-        senderLid = `${senderLid}@s.whatsapp.net`;
-      }
+      const senderLid = normalizeUserLid(sender);
 
       let userFind = await users.findOne({ userLid: senderLid });
 

--- a/src/commands/geral/sticker.js
+++ b/src/commands/geral/sticker.js
@@ -7,11 +7,12 @@ const fs = require('fs')
 const { exec } = require('child_process')
 const { version } = require("../../config");
 const { users } = require("../../database/models/users");
+const { normalizeUserLid } = require("../../utils/normalizeUserLid");
 
 
 module.exports = {
   name: "s",
-  async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     
     async function addExif(webpPath, packname = 'Yukizinha', author = 'Speed') {
   const img = new webp.Image();
@@ -130,7 +131,7 @@ const subdados = `↦ ✨𝑭𝒆𝒊𝒕𝒐 𝒑𝒐𝒓: ${pushname} • ${ti
       
       await sock.sendMessage(jid, { sticker: stickerBuffer }, { quoted: msg });
       
-      await users.updateOne({userLid: msg.key.participant}, {$inc: {figurinhas: 1}});
+      await users.updateOne({userLid: normalizeUserLid(sender)}, {$inc: {figurinhas: 1}});
 
       await fs.unlinkSync(inputPath);
       await fs.unlinkSync(outputPath);

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -2,7 +2,7 @@ const mongoose = require("mongoose");
 
 
 const userSchema = new mongoose.Schema({
-  userLid: {type: String, required: true},
+  userLid: {type: String, required: true, unique: true},
   name: {type: String, required: true},
   bio: {type: String, default: "Olá, amo a Yuki!"},
   isVip: {type: Boolean, default: false},

--- a/src/events/messages.js
+++ b/src/events/messages.js
@@ -19,6 +19,7 @@ const{ yukiEv,
 const { advertidos } = require("../database/models/adverts.js");
 const addXp = require("../utils/xp.js");
 const YukiAI = require("../ai.js");
+const { normalizeUserLid } = require("../utils/normalizeUserLid");
 
     //Parte que lida com mensagens em lotes
     //fila de mensagens de cada grupo
@@ -113,7 +114,13 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     const msg = m.messages[0];
     if (msg.key.fromMe) return
     
-    const sender = msg?.key?.participantLid || msg.key.senderLid;
+    const senderRaw =
+      msg?.key?.participantLid ||
+      msg?.key?.senderLid ||
+      msg?.key?.participant ||
+      msg?.key?.remoteJid;
+
+    const sender = normalizeUserLid(senderRaw);
     
     const from = msg?.key.remoteJid || msg?.key?.participantLid
     
@@ -221,16 +228,16 @@ await users.updateOne({userLid: sender}, {$addToSet: {grupos: {id: from, nome: g
       usersSender = await users.findOne({userLid: sender})
     }
 
-    await rankativos.updateOne({userLid: msg.key.participant, from: from}, {$inc: {msg: 1}}, {upsert: true})
+    await rankativos.updateOne({userLid: sender, from: from}, {$inc: {msg: 1}}, {upsert: true})
 
      //se estiver alguem mutado
-    if(await mutados.findOne({userLid: msg.key.participant, grupo: from})) {
+    if(await mutados.findOne({userLid: sender, grupo: from})) {
       try {
-      const userMutado = await mutados.findOne({userLid: msg.key.participant, grupo: from});
+      const userMutado = await mutados.findOne({userLid: sender, grupo: from});
       //apaga todas as msg
       await sock.sendMessage(userMutado.grupo, {delete: msg.key})
       
-      const muteTentativa = await mutados.findOneAndUpdate({userLid: msg.key.participant, grupo: from}, {$inc: {tentativasMsg: 1}}, {new: true});
+      const muteTentativa = await mutados.findOneAndUpdate({userLid: sender, grupo: from}, {$inc: {tentativasMsg: 1}}, {new: true});
       //se a pessoa for desmutada antes
       if(!muteTentativa) return;
       //se ela tentar mandar mais de 3 mensagens
@@ -238,7 +245,7 @@ await users.updateOne({userLid: sender}, {$addToSet: {grupos: {id: from, nome: g
         //remove ela do grupo
         await sock.groupParticipantsUpdate(muteTentativa.grupo, [muteTentativa.userLid], 'remove');
         //apaga ela da colessao
-        await mutados.deleteOne({userLid: msg.key.participant, grupo: from});
+        await mutados.deleteOne({userLid: sender, grupo: from});
         
       }
       
@@ -757,7 +764,7 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
     //pausa a simulacao
     await sock.sendPresenceUpdate('paused', from);
 //adiciona no contador de comandos
-    await rankativos.updateOne({userLid: msg.key.participant, from: from}, {$inc: {cmdUsados: 1}}, {upsert: true})
+    await rankativos.updateOne({userLid: sender, from: from}, {$inc: {cmdUsados: 1}}, {upsert: true})
 //adiciona no contador do grupo
    if(from.endsWith("@g.us")) {
    await grupos.updateOne({groupId: from}, {$inc: {cmdUsados: 1}});

--- a/src/scripts/migrateNormalizeUserLid.js
+++ b/src/scripts/migrateNormalizeUserLid.js
@@ -1,0 +1,136 @@
+require("dotenv").config();
+const mongoose = require("mongoose");
+const { users } = require("../database/models/users");
+const { normalizeUserLid } = require("../utils/normalizeUserLid");
+
+function mergeUniqueObjects(list = [], keyField = "id") {
+  const map = new Map();
+
+  for (const item of list) {
+    if (!item || typeof item !== "object") continue;
+
+    const key =
+      keyField && item[keyField] != null
+        ? `${keyField}:${item[keyField]}`
+        : JSON.stringify(item);
+
+    if (!map.has(key)) {
+      map.set(key, item);
+    }
+  }
+
+  return Array.from(map.values());
+}
+
+function mergeDates(dates = [], pick = "max") {
+  const validDates = dates.filter(Boolean).map((date) => new Date(date));
+  if (!validDates.length) return null;
+
+  return pick === "min"
+    ? new Date(Math.min(...validDates.map((date) => date.getTime())))
+    : new Date(Math.max(...validDates.map((date) => date.getTime())));
+}
+
+function pickFirstTruthy(values = []) {
+  return values.find(Boolean) ?? null;
+}
+
+async function main() {
+  await mongoose.connect(process.env.URIDB);
+
+  const allUsers = await users.find({});
+  const groups = new Map();
+
+  for (const user of allUsers) {
+    const canonical = normalizeUserLid(user.userLid);
+    if (!canonical) continue;
+
+    if (!groups.has(canonical)) {
+      groups.set(canonical, []);
+    }
+
+    groups.get(canonical).push(user);
+  }
+
+  let mergedGroups = 0;
+  let deletedDocs = 0;
+
+  for (const [canonicalId, docs] of groups.entries()) {
+    if (docs.length === 1 && docs[0].userLid === canonicalId) {
+      continue;
+    }
+
+    const canonicalDoc =
+      docs.find((doc) => doc.userLid === canonicalId) || docs[0];
+
+    const merged = {
+      userLid: canonicalId,
+      name: pickFirstTruthy(docs.map((doc) => doc.name)) || "Sem nome",
+      bio: pickFirstTruthy(docs.map((doc) => doc.bio)) || "OlA, amo a Yuki!",
+      isVip: docs.some((doc) => doc.isVip),
+      vencimentoVip: mergeDates(docs.map((doc) => doc.vencimentoVip), "max"),
+      registro: mergeDates(docs.map((doc) => doc.registro), "min") || new Date(),
+      prefixo: docs.some((doc) => doc.prefixo !== false),
+      daily: mergeDates(docs.map((doc) => doc.daily), "max"),
+      waifus: mergeUniqueObjects(docs.flatMap((doc) => doc.waifus || [])),
+      conquistas: mergeUniqueObjects(docs.flatMap((doc) => doc.conquistas || [])),
+      dinheiro: Math.max(...docs.map((doc) => Number(doc.dinheiro || 0))),
+      donwloads: docs.reduce((sum, doc) => sum + Number(doc.donwloads || 0), 0),
+      figurinhas: docs.reduce((sum, doc) => sum + Number(doc.figurinhas || 0), 0),
+      cmdCount: docs.reduce((sum, doc) => sum + Number(doc.cmdCount || 0), 0),
+      level: Math.max(...docs.map((doc) => Number(doc.level || 0))),
+      xp: docs.reduce((sum, doc) => sum + Number(doc.xp || 0), 0),
+      proximolevel: Math.max(...docs.map((doc) => Number(doc.proximolevel || 100))),
+      grupos: mergeUniqueObjects(docs.flatMap((doc) => doc.grupos || [])),
+      casal: {
+        parceiro: pickFirstTruthy(docs.map((doc) => doc?.casal?.parceiro)),
+        pedido: mergeDates(docs.map((doc) => doc?.casal?.pedido), "max"),
+        filhos: Array.from(
+          new Set(docs.flatMap((doc) => doc?.casal?.filhos || []).filter(Boolean))
+        )
+      }
+    };
+
+    await users.updateOne(
+      { _id: canonicalDoc._id },
+      { $set: merged },
+      { runValidators: false }
+    );
+
+    const duplicateIds = docs
+      .filter((doc) => String(doc._id) !== String(canonicalDoc._id))
+      .map((doc) => doc._id);
+
+    if (duplicateIds.length) {
+      const result = await users.deleteMany({ _id: { $in: duplicateIds } });
+      deletedDocs += result.deletedCount || 0;
+    }
+
+    mergedGroups += 1;
+    console.log(
+      `Mesclado ${canonicalId}: ${docs.length} registros -> 1 registro canOnico`
+    );
+  }
+
+  await users.collection.createIndex({ userLid: 1 }, { unique: true });
+
+  console.log(
+    JSON.stringify(
+      {
+        mergedGroups,
+        deletedDocs,
+        totalUsersAfter: await users.countDocuments()
+      },
+      null,
+      2
+    )
+  );
+
+  await mongoose.disconnect();
+}
+
+main().catch(async (error) => {
+  console.error(error);
+  await mongoose.disconnect();
+  process.exit(1);
+});

--- a/src/scripts/migrateNormalizeUserLid.mongosh.js
+++ b/src/scripts/migrateNormalizeUserLid.mongosh.js
@@ -1,0 +1,128 @@
+function normalizeUserLid(rawId) {
+  if (!rawId || typeof rawId !== "string") return null;
+
+  const trimmed = rawId.trim();
+  if (!trimmed) return null;
+
+  const parts = trimmed.split("@");
+  const localPart = (parts[0] || "").split(":")[0];
+  const domainPart = parts[1];
+
+  if (!localPart) return null;
+
+  if (!domainPart) return localPart + "@lid";
+  if (domainPart === "g.us" || domainPart === "broadcast") {
+    return localPart + "@" + domainPart;
+  }
+  return localPart + "@lid";
+}
+
+function mergeUniqueObjects(list, keyField) {
+  const map = new Map();
+
+  (list || []).forEach((item) => {
+    if (!item || typeof item !== "object") return;
+
+    const key =
+      keyField && item[keyField] != null
+        ? keyField + ":" + item[keyField]
+        : JSON.stringify(item);
+
+    if (!map.has(key)) {
+      map.set(key, item);
+    }
+  });
+
+  return Array.from(map.values());
+}
+
+function mergeDates(dates, pick) {
+  const validDates = (dates || [])
+    .filter(Boolean)
+    .map((date) => new Date(date))
+    .filter((date) => !Number.isNaN(date.getTime()));
+
+  if (!validDates.length) return null;
+
+  const timestamps = validDates.map((date) => date.getTime());
+  return new Date(pick === "min" ? Math.min.apply(null, timestamps) : Math.max.apply(null, timestamps));
+}
+
+function firstTruthy(values) {
+  for (const value of values || []) {
+    if (value) return value;
+  }
+  return null;
+}
+
+const allUsers = db.users.find().toArray();
+const groups = new Map();
+
+allUsers.forEach((user) => {
+  const canonical = normalizeUserLid(user.userLid);
+  if (!canonical) return;
+
+  if (!groups.has(canonical)) {
+    groups.set(canonical, []);
+  }
+
+  groups.get(canonical).push(user);
+});
+
+let mergedGroups = 0;
+let deletedDocs = 0;
+
+for (const [canonicalId, docs] of groups.entries()) {
+  if (docs.length === 1 && docs[0].userLid === canonicalId) {
+    continue;
+  }
+
+  const canonicalDoc = docs.find((doc) => doc.userLid === canonicalId) || docs[0];
+  const merged = {
+    userLid: canonicalId,
+    name: firstTruthy(docs.map((doc) => doc.name)) || "Sem nome",
+    bio: firstTruthy(docs.map((doc) => doc.bio)) || "Ola, amo a Yuki!",
+    isVip: docs.some((doc) => !!doc.isVip),
+    vencimentoVip: mergeDates(docs.map((doc) => doc.vencimentoVip), "max"),
+    registro: mergeDates(docs.map((doc) => doc.registro), "min") || new Date(),
+    prefixo: docs.some((doc) => doc.prefixo !== false),
+    daily: mergeDates(docs.map((doc) => doc.daily), "max"),
+    waifus: mergeUniqueObjects(docs.flatMap((doc) => doc.waifus || [])),
+    conquistas: mergeUniqueObjects(docs.flatMap((doc) => doc.conquistas || [])),
+    dinheiro: Math.max.apply(null, docs.map((doc) => Number(doc.dinheiro || 0))),
+    donwloads: docs.reduce((sum, doc) => sum + Number(doc.donwloads || 0), 0),
+    figurinhas: docs.reduce((sum, doc) => sum + Number(doc.figurinhas || 0), 0),
+    cmdCount: docs.reduce((sum, doc) => sum + Number(doc.cmdCount || 0), 0),
+    level: Math.max.apply(null, docs.map((doc) => Number(doc.level || 0))),
+    xp: docs.reduce((sum, doc) => sum + Number(doc.xp || 0), 0),
+    proximolevel: Math.max.apply(null, docs.map((doc) => Number(doc.proximolevel || 100))),
+    grupos: mergeUniqueObjects(docs.flatMap((doc) => doc.grupos || []), "id"),
+    casal: {
+      parceiro: firstTruthy(docs.map((doc) => doc.casal && doc.casal.parceiro)),
+      pedido: mergeDates(docs.map((doc) => doc.casal && doc.casal.pedido), "max"),
+      filhos: Array.from(new Set(docs.flatMap((doc) => (doc.casal && doc.casal.filhos) || []).filter(Boolean)))
+    }
+  };
+
+  db.users.updateOne({ _id: canonicalDoc._id }, { $set: merged });
+
+  const duplicateIds = docs
+    .filter((doc) => String(doc._id) !== String(canonicalDoc._id))
+    .map((doc) => doc._id);
+
+  if (duplicateIds.length) {
+    const result = db.users.deleteMany({ _id: { $in: duplicateIds } });
+    deletedDocs += result.deletedCount || 0;
+  }
+
+  mergedGroups += 1;
+  print("Mesclado " + canonicalId + ": " + docs.length + " registros -> 1");
+}
+
+db.users.createIndex({ userLid: 1 }, { unique: true });
+
+printjson({
+  mergedGroups,
+  deletedDocs,
+  totalUsersAfter: db.users.countDocuments()
+});

--- a/src/utils/instagram.js
+++ b/src/utils/instagram.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const { users } = require("../database/models/users");
+const { normalizeUserLid } = require("./normalizeUserLid");
 
 async function instaDl(sock, msg, from, body, erros_prontos, espera_pronta) {
   
@@ -18,7 +19,14 @@ async function instaDl(sock, msg, from, body, erros_prontos, espera_pronta) {
     
     await sock.sendMessage(from, {video: {url: data.resultados[0].url}, caption: "Yuki reels!"}, {quoted: msg});
     
-    await users.updateOne({userLid: msg.key.participant}, {$inc: {donwloads: 1}});
+    const sender = normalizeUserLid(
+      msg?.key?.participantLid ||
+      msg?.key?.senderLid ||
+      msg?.key?.participant ||
+      msg?.key?.remoteJid
+    );
+
+    await users.updateOne({userLid: sender}, {$inc: {donwloads: 1}});
     
     
     

--- a/src/utils/normalizeUserLid.js
+++ b/src/utils/normalizeUserLid.js
@@ -1,0 +1,25 @@
+function normalizeUserLid(rawId) {
+  if (!rawId || typeof rawId !== "string") return null;
+
+  const trimmed = rawId.trim();
+  if (!trimmed) return null;
+
+  const [localPart, domainPart] = trimmed.split("@");
+  const baseLocal = (localPart || "").split(":")[0];
+
+  if (!baseLocal) return null;
+
+  if (domainPart) {
+    if (domainPart === "g.us" || domainPart === "broadcast") {
+      return `${baseLocal}@${domainPart}`;
+    }
+
+    return `${baseLocal}@lid`;
+  }
+
+  return `${baseLocal}@lid`;
+}
+
+module.exports = {
+  normalizeUserLid
+};

--- a/src/utils/tiktok.js
+++ b/src/utils/tiktok.js
@@ -1,6 +1,7 @@
 const axios = require("axios");
 const { users } = require("../database/models/users");
 const path = require("path");
+const { normalizeUserLid } = require("./normalizeUserLid");
 
 async function tiktokDl(sock, msg, from, body, erros_prontos, espera_pronta) {
   try {
@@ -48,7 +49,14 @@ async function tiktokDl(sock, msg, from, body, erros_prontos, espera_pronta) {
 ⤷ *Comercial?* ${result.music.isOriginalSound ? 'Sim' : 'Não'}
 ⤷ *Som original?* ${result.music.isOriginalSound ? 'Sim' : 'Não'}`
 
-await users.updateOne({userLid: msg.key.participant}, {$inc: {donwloads: 1}});
+const sender = normalizeUserLid(
+  msg?.key?.participantLid ||
+  msg?.key?.senderLid ||
+  msg?.key?.participant ||
+  msg?.key?.remoteJid
+);
+
+await users.updateOne({userLid: sender}, {$inc: {donwloads: 1}});
 
 if(result.type === 'image') {
   const images = result.images


### PR DESCRIPTION
 corrigi a raiz da duplicação de usuários no banco, padronizando o identificador antes de qualquer leitura ou gravação no Mongo. Agora o bot trata o mesmo usuário sempre como um único registro canônico, removendo sufixos de dispositivo como :58 que tava acontecendo comigo e evitando a criação de clones como @s.whatsapp.net e @lid para a mesma pessoa.

Também foram ajustados os pontos do fluxo que ainda gravavam IDs crus, incluindo saldo, contagem de comandos, XP, downloads e figurinhas. Além disso, foi adicionada a migração para mesclar os registros antigos duplicados e foi criado um índice único em users.userLid para impedir que o problema volte.

Arquivos alterados:
- src/utils/normalizeUserLid.js
- src/events/messages.js
- src/commands/economia/saldo.js
- src/database/models/users.js
- src/scripts/migrateNormalizeUserLid.mongosh.js
- src/scripts/migrateNormalizeUserLid.js

Validação:
- sintaxe dos arquivos alterados verificada
- migração executada com sucesso no Mongo
- registros duplicados consolidados
- índice único criado em users.userLid

aliás, 
⠀⠀⠀⠀⠀⠀⠀⣠⣤⣤⣤⣤⣤⣄⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⢰⡿⠋⠁⠀⠀⠈⠉⠙⠻⣷⣄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⢀⣿⠇⠀⢀⣴⣶⡾⠿⠿⠿⢿⣿⣦⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⣀⣀⣸⡿⠀⠀⢸⣿⣇⠀⠀⠀⠀⠀⠀⠙⣷⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⣾⡟⠛⣿⡇⠀⠀⢸⣿⣿⣷⣤⣤⣤⣤⣶⣶⣿⠇⠀⠀⠀⠀⠀⠀⠀⣀⠀⠀
⢀⣿⠀⢀⣿⡇⠀⠀⠀⠻⢿⣿⣿⣿⣿⣿⠿⣿⡏⠀⠀⠀⠀⢴⣶⣶⣿⣿⣿⣆
⢸⣿⠀⢸⣿⡇⠀⠀⠀⠀⠀⠈⠉⠁⠀⠀⠀⣿⡇⣀⣠⣴⣾⣮⣝⠿⠿⠿⣻⡟
⢸⣿⠀⠘⣿⡇⠀⠀⠀⠀⠀⠀⠀⣠⣶⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠁⠉⠀
⠸⣿⠀⠀⣿⡇⠀⠀⠀⠀⠀⣠⣾⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠟⠉⠀⠀⠀⠀
⠀⠻⣷⣶⣿⣇⠀⠀⠀⢠⣼⣿⣿⣿⣿⣿⣿⣿⣛⣛⣻⠉⠁⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⢸⣿⠀⠀⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⢸⣿⣀⣀⣀⣼⡿⢿⣿⣿⣿⣿⣿⡿⣿⣿⡿⠀⠀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⠀⠀⠀⠙⠛⠛⠛⠋⠁⠀⠙⠻⠿⠟⠋⠑⠛⠋⠀