### PR TITLE
fix(ai): yuki volta a responder quando falarem com ela direto

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -32,6 +32,7 @@ RELACIONAMENTO
 - Se o usuário for o Speed, responda com deboche leve e consistente.
 - Nunca trate o Speed com formalidade excessiva.
 ${mode === "owner" ? "- O nome de um dono foi citado. Comente a conversa de forma natural, curta e com leve ironia.\n" : ""}
+${mode === "reply" ? "- O usuário respondeu uma mensagem sua. Continue o assunto de forma natural e curta, como uma conversa normal.\n" : ""}
 ${mode === "ambient" ? "- O grupo está em modo silencioso. Seja mais contida e só puxe assunto se a conversa recente permitir.\n" : ""}
 ${isSpeed ? "- O usuário atual é o Speed. Priorize a regra do Speed acima de tudo.\n" : ""}
 

--- a/src/events/messages.js
+++ b/src/events/messages.js
@@ -144,6 +144,8 @@ async function safeRedis(action, fallback = null) {
       /\?/,
       /\b(opina|acha|concorda|discorda|melhor|pior|qual|quem|sera|sera que|pq|por que|faz sentido|nao sei|deveria|vale a pena)\b/
     ];
+    const AI_DIRECT_GROUP_COOLDOWN_MS = 12 * 1000;
+    const AI_DIRECT_SENDER_COOLDOWN_MS = 6 * 1000;
 
     function stripAccents(value) {
       return String(value ?? "")
@@ -181,6 +183,10 @@ async function safeRedis(action, fallback = null) {
         normalizedQuotedParticipant,
         normalizedQuotedRemoteJid
       ].some((candidate) => candidate && [normalizedBotLid, normalizedBotJid].includes(candidate));
+    }
+
+    function isStrongAiTrigger(kind) {
+      return ["owner", "reply", "yuki"].includes(kind);
     }
 
     function getAiState(groupId) {
@@ -421,11 +427,14 @@ async function safeRedis(action, fallback = null) {
       const now = Date.now();
       const groupGap = now - (state.lastReplyAt || 0);
       const senderGap = now - (state.lastSenderReplyAt.get(sender) || 0);
+      const strongTrigger = isStrongAiTrigger(trigger.kind);
+      const minGroupGap = strongTrigger ? AI_DIRECT_GROUP_COOLDOWN_MS : profile.cooldownMs;
+      const minSenderGap = strongTrigger ? AI_DIRECT_SENDER_COOLDOWN_MS : profile.senderCooldownMs;
 
-      if (groupGap < profile.cooldownMs) return false;
-      if (!["owner", "reply"].includes(trigger.kind) && senderGap < profile.senderCooldownMs) return false;
+      if (groupGap < minGroupGap) return false;
+      if (senderGap < minSenderGap) return false;
 
-      const chance = Math.min(0.96, trigger.baseChance * profile.chanceScale);
+      const chance = strongTrigger ? 1 : Math.min(0.96, trigger.baseChance * profile.chanceScale);
       if (Math.random() > chance) return false;
 
       try {
@@ -436,7 +445,7 @@ async function safeRedis(action, fallback = null) {
           chat: from,
           user: msg?.pushName || "sem nome",
           context: state.recent,
-          mode: ["owner", "reply"].includes(trigger.kind) ? "owner" : "context"
+          mode: trigger.kind === "reply" ? "reply" : trigger.kind === "owner" ? "owner" : "context"
         });
 
         if (!response) {


### PR DESCRIPTION
## O que eu corrigi

Corrigi a regressão que travou a parte de respostas da Yuki no grupo.

Depois da mudança de contexto/silêncio, os gatilhos fortes da conversa estavam caindo no mesmo cooldown pesado usado pras respostas mais espontâneas. Na prática, isso fazia a Yuki parar de responder direito mesmo quando falavam com ela diretamente.

## O que eu ajustei

- se falarem `yuki` direto, ela volta a responder como gatilho forte;
- se responderem uma mensagem da própria Yuki, ela continua o assunto sem depender do mesmo cooldown pesado do modo espontâneo;
- se citarem dono, isso também continua entrando como gatilho forte;
- deixei o cooldown curto só pras interações diretas;
- mantive o cooldown maior e a probabilidade anti-spam só pras respostas por contexto e silêncio.

## Impacto

Isso devolve o comportamento natural da conversa:

- falar com a Yuki volta a funcionar de forma consistente;
- responder uma mensagem dela continua o papo;
- o modo contextual e o modo silencioso continuam com freio pra não virar spam.

## Validação

- `node --check src/ai.js`
- `node --check src/events/messages.js`