### PR TITLE
Codex/tiktok api yuki integration

### DIFF
--- a/src/api/tiktok-api/app/parsers/video_parser.py
+++ b/src/api/tiktok-api/app/parsers/video_parser.py
@@ -209,6 +209,18 @@ async def _quality_item_from_format(fmt: dict, source_key: str | None = None) ->
     }
 
 
+def _quality_sort_key(item: dict) -> tuple[int, int, int]:
+    resolution = item.get("resolution") or {}
+    height = resolution.get("height") or 0
+    width = resolution.get("width") or 0
+    bitrate = item.get("bitrate") or 0
+    try:
+        return (int(height), int(width), int(bitrate))
+    except (TypeError, ValueError):
+        logger.warning("Invalid quality sort values for %s", item.get("format_id") or item.get("variant"))
+        return (0, 0, 0)
+
+
 def _tikwm_quality_items(tikwm_data: dict | None) -> list[dict]:
     if not tikwm_data:
         return []
@@ -319,27 +331,20 @@ async def parse_raw_info(raw: dict, tikwm: dict | None = None) -> dict:
 
     variant_counts = {}
     for item in quality_items:
-        key = (item.get("access"), item.get("variant"))
+        key = f"{item.get('access') or ''}|{item.get('variant') or ''}"
         variant_counts[key] = variant_counts.get(key, 0) + 1
 
     variant_seen = {}
     for item in quality_items:
         access = item.get("access") or _quality_access_icon(item.get("url"))
         variant = item.get("variant") or "unknown"
-        key = (access, variant)
+        key = f"{access}|{variant}"
         if variant_counts.get(key, 0) > 1:
             variant_seen[key] = variant_seen.get(key, 0) + 1
             variant = f"{variant}_{variant_seen[key]}"
         item["label"] = f"{access} {variant}"
 
-    quality_items.sort(
-        key=lambda item: (
-            item["resolution"]["height"] if item.get("resolution") else 0,
-            item["resolution"]["width"] if item.get("resolution") else 0,
-            item.get("bitrate") or 0,
-        ),
-        reverse=True,
-    )
+    quality_items.sort(key=_quality_sort_key, reverse=True)
 
     source = raw.get("source") or "Soon"
     extractor = raw.get("extractor")

--- a/src/api/tiktok-api/app/routers/video.py
+++ b/src/api/tiktok-api/app/routers/video.py
@@ -6,7 +6,6 @@ from fastapi.responses import PlainTextResponse, StreamingResponse
 
 from app.formatters.text_panel import build_text_panel
 from app.parsers.video_parser import extract_video_id, parse_raw_info
-from app.services.video_utils import get_best_format
 from app.services.ytdlp import get_raw_info
 from app.services.tikwm import get_tikwm_info
 
@@ -26,6 +25,53 @@ TIKTOK_HEADERS = {
     "Sec-Fetch-Mode": "no-cors",
     "Sec-Fetch-Site": "cross-site",
 }
+
+
+def _is_likely_downloadable_quality(item: dict) -> bool:
+    source = str(item.get("source") or "")
+    url = str(item.get("url") or "")
+    return source.startswith("tikwm:") or "webapp-prime.tiktok.com" not in url.lower()
+
+
+def _quality_rank(item: dict) -> tuple[int, int, int]:
+    resolution = item.get("resolution") or {}
+    width = int(resolution.get("width") or 0)
+    height = int(resolution.get("height") or 0)
+    bitrate = int(item.get("bitrate") or 0)
+    file_size = int(item.get("file_size") or 0)
+    return (width * height, bitrate, file_size)
+
+
+def _select_download_quality(data: dict, quality: str) -> dict | None:
+    qualities = [item for item in data.get("qualities", []) if item.get("url")]
+    if not qualities:
+        return None
+
+    lowered = quality.lower()
+    if lowered in ("highest", "original", "best"):
+        downloadable = [item for item in qualities if _is_likely_downloadable_quality(item)]
+        candidates = downloadable or qualities
+        return max(candidates, key=_quality_rank)
+
+    if lowered in ("medium", "normal"):
+        for item in qualities:
+            source = str(item.get("source") or "")
+            variant = str(item.get("variant") or "")
+            if source.startswith("tikwm:") and variant == "play_addr":
+                return item
+        downloadable = [item for item in qualities if _is_likely_downloadable_quality(item)]
+        candidates = downloadable or qualities
+        return max(candidates, key=_quality_rank)
+
+    for item in qualities:
+        if quality in {
+            str(item.get("format_id") or ""),
+            str(item.get("variant") or ""),
+            str(item.get("label") or ""),
+        }:
+            return item
+
+    return None
 
 
 def _resolve_input(url: str | None, video_id: str | None) -> str:
@@ -88,58 +134,68 @@ async def download_video(
         logger.exception("Extraction error")
         raise HTTPException(status_code=502, detail=f"Extraction failed: {exc}") from exc
 
-    formats = raw.get("formats", [])
-    selected = get_best_format(formats, quality)
-    if not selected:
-        available = [fmt.get("format_id") for fmt in formats]
-        raise HTTPException(status_code=404, detail=f"No format for {quality}. Available: {available}")
+    tikwm = await get_tikwm_info(video_input)
+    data = await parse_raw_info(raw, tikwm=tikwm)
 
-    file_url = selected.get("url")
+    media_type = "video/mp4"
+    filename = f"{vid}_video.mp4"
+    if quality.lower() == "audio":
+        file_url = (data.get("sound") or {}).get("url")
+        media_type = "audio/mpeg"
+        filename = f"{vid}_audio.mp3"
+    else:
+        selected = _select_download_quality(data, quality)
+        if not selected:
+            available = [item.get("format_id") or item.get("variant") for item in data.get("qualities", [])]
+            raise HTTPException(status_code=404, detail=f"No format for {quality}. Available: {available}")
+        file_url = selected.get("url")
+
     if not file_url:
-        raise HTTPException(status_code=404, detail="No URL for selected format")
+        raise HTTPException(status_code=404, detail="No URL for selected media")
 
     headers = TIKTOK_HEADERS.copy()
     headers["Referer"] = raw.get("webpage_url", "https://www.tiktok.com/")
 
     try:
+        probe_headers = headers.copy()
+        probe_headers["Range"] = "bytes=0-1023"
         async with aiohttp.ClientSession() as session:
-            async with session.head(
+            async with session.get(
                 file_url,
-                headers=headers,
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as head_resp:
-                logger.info("CDN HEAD status: %s", head_resp.status)
-                if head_resp.status == 404:
+                headers=probe_headers,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as probe_resp:
+                logger.info("CDN probe status: %s", probe_resp.status)
+                if probe_resp.status == 404:
                     raise HTTPException(status_code=404, detail="Video no longer available on CDN")
-                if head_resp.status not in (200, 206, 403):
-                    raise HTTPException(status_code=502, detail=f"CDN returned status {head_resp.status}")
+                if probe_resp.status not in (200, 206):
+                    error_body = await probe_resp.text()
+                    logger.error("CDN probe failed: %s - %s", probe_resp.status, error_body[:200])
+                    raise HTTPException(status_code=502, detail=f"CDN returned status {probe_resp.status}")
 
-            filename = f"{vid}_video.mp4"
-            if quality == "audio":
-                filename = f"{vid}_audio.mp3"
-
-            async def stream_file():
+        async def stream_file():
+            async with aiohttp.ClientSession() as session:
                 async with session.get(
                     file_url,
                     headers=headers,
-                    timeout=aiohttp.ClientTimeout(total=60),
+                    timeout=aiohttp.ClientTimeout(total=None, sock_connect=20, sock_read=120),
                 ) as resp:
                     if resp.status not in (200, 206):
                         error_body = await resp.text()
                         logger.error("CDN GET failed: %s - %s", resp.status, error_body[:200])
-                        raise HTTPException(status_code=502, detail=f"CDN GET failed: {resp.status}")
+                        return
 
                     async for chunk in resp.content.iter_chunked(1024 * 1024):
                         yield chunk
 
-            return StreamingResponse(
-                stream_file(),
-                media_type="video/mp4" if quality != "audio" else "audio/mpeg",
-                headers={
-                    "Content-Disposition": f"attachment; filename={filename}",
-                    "Accept-Ranges": "bytes",
-                },
-            )
+        return StreamingResponse(
+            stream_file(),
+            media_type=media_type,
+            headers={
+                "Content-Disposition": f"attachment; filename={filename}",
+                "Accept-Ranges": "bytes",
+            },
+        )
     except aiohttp.ClientError as exc:
         logger.error("Download error: %s", exc)
         raise HTTPException(status_code=502, detail=f"Failed to fetch from CDN: {exc}") from exc


### PR DESCRIPTION
## o que eu fiz

trouxe a API de TikTok pra dentro da própria repo da Yuki e finalizei a integração entre API + bot, deixando o fluxo de análise e download funcionando de forma local e versionada junto com o restante do projeto.

esse PR fecha o caminho inteiro do TikTok na Yuki:
- a bot chama a API local
- `/check` mostra analytics do vídeo
- `/download` oferece as opções de envio
- o envio vai como documento, pra não recomprimir no WhatsApp
- o auto comportamento por link cru foi removido, então o TikTok agora responde só quando a pessoa pedir por comando

## o que mudou na prática

### API TikTok dentro da repo
a API agora vive em `src/api/tiktok-api`, com FastAPI, `yt-dlp` como base e TikWM como fallback apenas para preencher o que vier nulo.

ela passou a entregar:
- id do vídeo
- usuário e perfil
- data de postagem em `America/Sao_Paulo`
- legenda
- região
- status de shadow ban como `N/A`
- som e duração
- stats
- origem do vídeo
- todas as qualidades disponíveis
- categorias, tags e dicas de conteúdo

### correção do `/check`
o `/check` estava quebrando em alguns vídeos porque o parser da API tentava ordenar qualidades com campos nulos.

isso foi corrigido para:
- não quebrar quando `width`, `height` ou `bitrate` vierem nulos
- continuar retornando todas as qualidades
- manter a ordenação das variantes sem derrubar a resposta

### correção do `/download`
o `/download` também estava instável porque a rota antiga podia escolher uma URL `webapp-prime` bloqueada pelo TikTok, o que gerava `403` e derrubava a conexão.

agora a API:
- escolhe uma qualidade realmente baixável
- evita URLs que costumam retornar `403`
- faz probe antes do stream final
- mantém a conexão aberta até o arquivo terminar
- continua permitindo baixar como documento

### integração na bot
na Yuki, os comandos passaram a consumir a API local:
- `[src/utils/tiktok.js](C:/Users/luisf/Projects/bot/YukiV3/src/utils/tiktok.js)`
- `[src/commands/api/check.js](C:/Users/luisf/Projects/bot/YukiV3/src/commands/api/check.js)`
- `[src/commands/api/download.js](C:/Users/luisf/Projects/bot/YukiV3/src/commands/api/download.js)`

também ficou assim:
- `[src/events/messages.js](C:/Users/luisf/Projects/bot/YukiV3/src/events/messages.js)` não responde mais automaticamente quando alguém manda link de TikTok no grupo
- `source` da API passou a voltar `"Soon"`
- `posted_at` volta convertido antes de sair da API
- o envio de mídia agora acontece como documento, para não recomprimir

## arquivos principais tocados

- `[src/api/tiktok-api/app/main.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/main.py)`
- `[src/api/tiktok-api/app/config.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/config.py)`
- `[src/api/tiktok-api/app/routers/video.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/routers/video.py)`
- `[src/api/tiktok-api/app/parsers/video_parser.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/parsers/video_parser.py)`
- `[src/api/tiktok-api/app/services/ytdlp.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/services/ytdlp.py)`
- `[src/api/tiktok-api/app/services/tikwm.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/services/tikwm.py)`
- `[src/api/tiktok-api/app/services/cache.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/services/cache.py)`
- `[src/api/tiktok-api/app/services/video_utils.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/services/video_utils.py)`
- `[src/api/tiktok-api/app/formatters/text_panel.py](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/app/formatters/text_panel.py)`
- `[src/api/tiktok-api/requirements.txt](C:/Users/luisf/Projects/bot/YukiV3/src/api/tiktok-api/requirements.txt)`
- `[src/commands/api/check.js](C:/Users/luisf/Projects/bot/YukiV3/src/commands/api/check.js)`
- `[src/commands/api/download.js](C:/Users/luisf/Projects/bot/YukiV3/src/commands/api/download.js)`
- `[src/utils/tiktok.js](C:/Users/luisf/Projects/bot/YukiV3/src/utils/tiktok.js)`
- `[src/events/messages.js](C:/Users/luisf/Projects/bot/YukiV3/src/events/messages.js)`
- `[start.sh](C:/Users/luisf/Projects/bot/YukiV3/start.sh)`
- `[start.bat](C:/Users/luisf/Projects/bot/YukiV3/start.bat)`
- `[.gitignore](C:/Users/luisf/Projects/bot/YukiV3/.gitignore)`

## como testar

### subir a API
na raiz da API:

```powershell
cd C:\Users\luisf\Projects\bot\YukiV3\src\api\tiktok-api
.\venv\Scripts\python.exe -m pip install -r requirements.txt
.\venv\Scripts\python.exe -m uvicorn app.main:app --host 127.0.0.1 --port 8000
testar o /check
$url = "https://www.tiktok.com/@ndrewnat06/video/7639213436160855309?is_from_webapp=1&sender_device=pc"
Invoke-RestMethod "http://127.0.0.1:8000/video/info?url=$([uri]::EscapeDataString($url))" | ConvertTo-Json -Depth 10
o esperado é:

JSON com analytics completos
qualidades listadas
região preenchida
fonte como "Soon" quando não houver fonte explícita
posted_at convertido para America/Sao_Paulo
testar o /download
$url = "https://www.tiktok.com/@ndrewnat06/video/7639213436160855309?is_from_webapp=1&sender_device=pc"
Invoke-WebRequest "http://127.0.0.1:8000/video/download?quality=highest&url=$([uri]::EscapeDataString($url))" -OutFile "$env:TEMP\tiktok-test.mp4"
Get-Item "$env:TEMP\tiktok-test.mp4"
o esperado é:

o arquivo baixar inteiro
não fechar a conexão no meio
o tamanho final vir completo
testar na bot
na Yuki, os comandos ficam:

/check <url>
/download <url>
e o comportamento esperado é:

/check retorna analytics
/download mostra as 3 opções
link cru de TikTok no grupo não dispara resposta automática
validação que eu rodei
python -m py_compile nos arquivos principais da API
teste do /video/info com a URL de @ndrewnat06
teste do /video/download com a mesma URL
validação de que o download completa de verdade
confirmação de que o parser não quebra mais com qualidades nulas
observação final
esse PR não reescreve a bot inteira. ele só corrige o que estava quebrado e deixa a integração TikTok mais estável, mais previsível e mais alinhada com o uso real na Yuki.