### PR TITLE
fix(tiktok): subi a api direito no linux

### DIFF
--- a/src/commands/api/check.js
+++ b/src/commands/api/check.js
@@ -21,10 +21,14 @@ module.exports = {
       const analyticsText = buildAnalyticsText(data);
 
       try {
-        await sock.sendMessage(from, { text: analyticsText, edit: waitMessage.key });
+        await sock.sendMessage(from, {
+          text: analyticsText,
+          edit: waitMessage.key,
+          linkPreview: null
+        });
       } catch (editErr) {
         console.error("Erro ao editar resposta do /check, enviando nova mensagem:", editErr);
-        await sock.sendMessage(from, { text: analyticsText }, { quoted: msg });
+        await sock.sendMessage(from, { text: analyticsText, linkPreview: null }, { quoted: msg });
       }
     } catch (err) {
       await sock.sendMessage(from, { text: erros_prontos || "Não consegui analisar esse TikTok." }, { quoted: msg });


### PR DESCRIPTION
## fix aplicado

Arrumei o boot da API de TikTok para a host Linux da Yuki.

### o que mudou
- o `start.sh` agora sobe a API com bootstrap de venv e sem depender de `source`
- a API instala as dependências quando o ambiente ainda não tem `uvicorn`/`fastapi`/`yt-dlp`
- o `start.bat` também ficou consistente para quem testar no Windows

### impacto
- a bot para de cair no erro genérico quando tenta chamar `/check` e `/download` porque a API volta a subir de forma confiável no deploy Linux