### PR TITLE
fix(tiktok): subi a api direito no linux

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -3,11 +3,12 @@ setlocal
 
 cd /d "%~dp0src\api\tiktok-api"
 
-if exist "venv\Scripts\activate.bat" (
-  call "venv\Scripts\activate.bat"
+if not exist "venv\Scripts\python.exe" (
+  python -m venv venv
 )
 
-start "yuki-tiktok-api" /B cmd /c "python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1"
+venv\Scripts\python.exe -m pip install -r requirements.txt
+start "yuki-tiktok-api" /B cmd /c "venv\Scripts\python.exe -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1"
 
 cd /d "%~dp0"
 node src\index.js

--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 echo "Iniciando API do TikTok..."
-cd src/api/tiktok-api
-source venv/bin/activate 2>/dev/null || true
-python -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1 &
-API_PID=$!
-cd ../../..
+cd src/api/tiktok-api || exit 1
 
-trap "kill $API_PID 2>/dev/null" EXIT
+PYTHON_BIN="${PYTHON_BIN:-}"
+if [ -z "$PYTHON_BIN" ]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python3)"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_BIN="$(command -v python)"
+  fi
+fi
+
+if [ -z "$PYTHON_BIN" ]; then
+  echo "Python nao encontrado."
+  exit 1
+fi
+
+VENV_PY="venv/bin/python"
+if [ ! -x "$VENV_PY" ]; then
+  "$PYTHON_BIN" -m venv venv || exit 1
+fi
+
+if [ ! -x "$VENV_PY" ]; then
+  echo "Nao consegui preparar o venv da API."
+  exit 1
+fi
+
+if ! "$VENV_PY" -c "import uvicorn, fastapi, yt_dlp, cachetools, aiohttp, aiofiles, pydantic" >/dev/null 2>&1; then
+  "$VENV_PY" -m pip install -r requirements.txt || exit 1
+fi
+
+"$VENV_PY" -m uvicorn app.main:app --host 127.0.0.1 --port 8000 > uvicorn.log 2>&1 &
+API_PID=$!
+cd ../../.. || exit 1
+
+trap 'kill "$API_PID" 2>/dev/null' EXIT INT TERM
 
 sleep 2
 


### PR DESCRIPTION
## fix aplicado

Arrumei o boot da API de TikTok para a host Linux da Yuki.

### o que mudou
- o `start.sh` agora sobe a API com bootstrap de venv e sem depender de `source`
- a API instala as dependências quando o ambiente ainda não tem `uvicorn`/`fastapi`/`yt-dlp`
- o `start.bat` também ficou consistente para quem testar no Windows

### impacto
- a bot para de cair no erro genérico quando tenta chamar `/check` e `/download` porque a API volta a subir de forma confiável no deploy Linux