### PR TITLE
feat(donos): criei announcement seguro pros grupos

### DIFF
--- a/src/commands/donos/annoucement.js
+++ b/src/commands/donos/annoucement.js
@@ -1,0 +1,345 @@
+const crypto = require("crypto");
+const { grupos } = require("../../database/models/grupos");
+const { donos } = require("../../database/models/donos");
+const { prefixo } = require("../../config");
+
+const pendingAnnouncements = new Map();
+
+let runningAnnouncement = null;
+let lastRunAt = 0;
+
+const DEFAULT_LIMIT = 15;
+const HARD_LIMIT = 25;
+const DEFAULT_MIN_DELAY_SECONDS = 90;
+const DEFAULT_MAX_DELAY_SECONDS = 180;
+const MIN_ALLOWED_DELAY_SECONDS = 60;
+const PENDING_TTL_MS = 10 * 60 * 1000;
+const RUN_COOLDOWN_MS = 30 * 60 * 1000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function randomBetween(min, max) {
+  return min + Math.floor(Math.random() * (max - min + 1));
+}
+
+function stripQuotes(value) {
+  return String(value || "").trim().replace(/^["'`]+|["'`]+$/g, "").trim();
+}
+
+function parseArgs(args) {
+  const options = {
+    dryRun: false,
+    limit: DEFAULT_LIMIT,
+    minDelay: DEFAULT_MIN_DELAY_SECONDS,
+    maxDelay: DEFAULT_MAX_DELAY_SECONDS,
+    textParts: []
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = String(args[i] || "").trim();
+    const lowered = arg.toLowerCase();
+
+    if (lowered === "--dry" || lowered === "--dry-run") {
+      options.dryRun = true;
+      continue;
+    }
+
+    if (lowered === "--limit") {
+      options.limit = Number(args[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (lowered === "--min-delay") {
+      options.minDelay = Number(args[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    if (lowered === "--max-delay") {
+      options.maxDelay = Number(args[i + 1]);
+      i += 1;
+      continue;
+    }
+
+    options.textParts.push(arg);
+  }
+
+  options.limit = Math.min(Math.max(Number(options.limit) || DEFAULT_LIMIT, 1), HARD_LIMIT);
+  options.minDelay = Math.max(Number(options.minDelay) || DEFAULT_MIN_DELAY_SECONDS, MIN_ALLOWED_DELAY_SECONDS);
+  options.maxDelay = Math.max(Number(options.maxDelay) || DEFAULT_MAX_DELAY_SECONDS, options.minDelay);
+  options.text = stripQuotes(options.textParts.join(" "));
+
+  return options;
+}
+
+async function getAnnouncementGroups(limit) {
+  const docs = await grupos
+    .find({ groupId: /@g\.us$/ })
+    .select("groupId grupoName configs")
+    .sort({ grupoName: 1 })
+    .lean();
+
+  const seen = new Set();
+  const enabled = docs.filter((group) => {
+    if (!group?.groupId || seen.has(group.groupId)) return false;
+    seen.add(group.groupId);
+    return group?.configs?.announcements !== false;
+  });
+
+  return {
+    total: enabled.length,
+    selected: enabled.slice(0, limit)
+  };
+}
+
+function buildBroadcastText(text, ownerName) {
+  return `📣 *Comunicado da Yuki*
+
+${text}
+
+_Enviado por ${ownerName || "um dono da Yuki"}._`;
+}
+
+async function runAnnouncement(sock, replyTo, quoted, pending) {
+  const result = {
+    sent: 0,
+    failed: 0,
+    skipped: 0,
+    errors: []
+  };
+
+  console.log(`[announcement] iniciando ${pending.id} com ${pending.groups.length} grupos`);
+
+  try {
+    for (const group of pending.groups) {
+      const delaySeconds = randomBetween(pending.minDelay, pending.maxDelay);
+      console.log(`[announcement] aguardando ${delaySeconds}s antes de enviar para ${group.groupId}`);
+      await sleep(delaySeconds * 1000);
+
+      try {
+        await sock.sendMessage(group.groupId, { text: pending.message });
+        result.sent += 1;
+        console.log(`[announcement] enviado para ${group.groupId} (${group.grupoName || "sem nome"})`);
+      } catch (err) {
+        result.failed += 1;
+        const errorText = err?.data || err?.message || String(err);
+        result.errors.push(`${group.grupoName || group.groupId}: ${errorText}`);
+        console.error(`[announcement] falhou em ${group.groupId}:`, errorText);
+
+        if (String(errorText).includes("429") || String(errorText).includes("rate")) {
+          const cooldown = pending.maxDelay * 2;
+          console.log(`[announcement] rate limit detectado, pausa extra de ${cooldown}s`);
+          await sleep(cooldown * 1000);
+        }
+      }
+    }
+
+    const errorsText = result.errors.length
+      ? `\n\nFalhas:\n${result.errors.slice(0, 8).map((item) => `• ${item}`).join("\n")}`
+      : "";
+
+    await sock.sendMessage(
+      replyTo,
+      {
+        text: `✅ Announcement finalizado.
+
+Enviados: ${result.sent}
+Falharam: ${result.failed}
+Pulados: ${result.skipped}${errorsText}`
+      },
+      { quoted }
+    );
+  } finally {
+    runningAnnouncement = null;
+  }
+}
+
+async function assertOwner(sock, msg, from, sender) {
+  const donoSender = await donos.findOne({ userLid: sender });
+  if (donoSender) return true;
+
+  await sock.sendMessage(from, { text: "Só dono pode usar announcement, meu mano." }, { quoted: msg });
+  return false;
+}
+
+async function handleConfirm(sock, msg, from, args, sender) {
+  const id = args[1];
+  const pending = pendingAnnouncements.get(id);
+
+  if (!pending || pending.sender !== sender || pending.expiresAt < Date.now()) {
+    pendingAnnouncements.delete(id);
+    await sock.sendMessage(from, { text: "Esse announcement expirou ou não é seu." }, { quoted: msg });
+    return;
+  }
+
+  if (runningAnnouncement) {
+    await sock.sendMessage(from, { text: `Já tem um announcement rodando agora: ${runningAnnouncement}` }, { quoted: msg });
+    return;
+  }
+
+  if (Date.now() - lastRunAt < RUN_COOLDOWN_MS) {
+    const remaining = Math.ceil((RUN_COOLDOWN_MS - (Date.now() - lastRunAt)) / 60000);
+    await sock.sendMessage(from, { text: `Segura um pouco: cooldown de segurança ativo por mais ${remaining} min.` }, { quoted: msg });
+    return;
+  }
+
+  pendingAnnouncements.delete(id);
+  runningAnnouncement = id;
+  lastRunAt = Date.now();
+
+  await sock.sendMessage(
+    from,
+    {
+      text: `📣 Announcement iniciado com segurança.
+
+Grupos: ${pending.groups.length}
+Delay: ${pending.minDelay}s a ${pending.maxDelay}s entre cada grupo
+
+Primeiro envio só sai depois do primeiro delay, pra evitar comportamento de spam.`
+    },
+    { quoted: msg }
+  );
+
+  runAnnouncement(sock, from, msg, pending).catch((err) => {
+    runningAnnouncement = null;
+    console.error("[announcement] erro geral:", err);
+  });
+}
+
+async function handleCancel(sock, msg, from, args, sender) {
+  const id = args[1];
+  const pending = pendingAnnouncements.get(id);
+
+  if (!pending || pending.sender !== sender) {
+    await sock.sendMessage(from, { text: "Não achei esse announcement pendente pra cancelar." }, { quoted: msg });
+    return;
+  }
+
+  pendingAnnouncements.delete(id);
+  await sock.sendMessage(from, { text: "Announcement cancelado, nada foi enviado." }, { quoted: msg });
+}
+
+module.exports = {
+  name: "annoucement",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      if (!(await assertOwner(sock, msg, from, sender))) return;
+
+      const action = String(args[0] || "").toLowerCase();
+      if (action === "confirm") {
+        await handleConfirm(sock, msg, from, args, sender);
+        return;
+      }
+
+      if (action === "cancel") {
+        await handleCancel(sock, msg, from, args, sender);
+        return;
+      }
+
+      if (action === "status") {
+        await sock.sendMessage(
+          from,
+          { text: runningAnnouncement ? `Announcement rodando: ${runningAnnouncement}` : "Nenhum announcement rodando agora." },
+          { quoted: msg }
+        );
+        return;
+      }
+
+      const options = parseArgs(args);
+      if (!options.text) {
+        await sock.sendMessage(
+          from,
+          {
+            text: `Use: ${prefixo || "/"}annoucement "texto do recado"
+
+Extras:
+• --dry pra testar sem enviar
+• --limit 10 pra limitar o lote
+• --min-delay 120 --max-delay 240 pra delays ainda mais pesados`
+          },
+          { quoted: msg }
+        );
+        return;
+      }
+
+      const { total, selected } = await getAnnouncementGroups(options.limit);
+      if (!selected.length) {
+        await sock.sendMessage(from, { text: "Não encontrei nenhum grupo cadastrado pra enviar." }, { quoted: msg });
+        return;
+      }
+
+      const message = buildBroadcastText(options.text, msg.pushName);
+      const previewGroups = selected
+        .slice(0, 8)
+        .map((group, index) => `${index + 1}. ${group.grupoName || group.groupId}`)
+        .join("\n");
+      const remainingText = total > selected.length
+        ? `\n\n⚠️ Existem ${total} grupos, mas por segurança esse lote vai mandar só para ${selected.length}.`
+        : "";
+
+      if (options.dryRun) {
+        await sock.sendMessage(
+          from,
+          {
+            text: `🧪 Dry-run do announcement.
+
+Grupos que receberiam: ${selected.length}/${total}
+Delay: ${options.minDelay}s a ${options.maxDelay}s
+
+Prévia:
+${message}
+
+Grupos:
+${previewGroups}${selected.length > 8 ? "\n..." : ""}${remainingText}`
+          },
+          { quoted: msg }
+        );
+        return;
+      }
+
+      const id = crypto.randomBytes(4).toString("hex");
+      pendingAnnouncements.set(id, {
+        id,
+        sender,
+        groups: selected,
+        message,
+        minDelay: options.minDelay,
+        maxDelay: options.maxDelay,
+        expiresAt: Date.now() + PENDING_TTL_MS
+      });
+
+      const buttons = [
+        { buttonId: `${prefixo || "/"}annoucement confirm ${id}`, buttonText: { displayText: "Confirmar envio" }, type: 1 },
+        { buttonId: `${prefixo || "/"}annoucement cancel ${id}`, buttonText: { displayText: "Cancelar" }, type: 1 }
+      ];
+
+      await sock.sendMessage(
+        from,
+        {
+          text: `📣 *Preview do announcement*
+
+Grupos: ${selected.length}/${total}
+Delay: ${options.minDelay}s a ${options.maxDelay}s entre grupos
+Expira em: 10 min
+
+Mensagem:
+${message}
+
+Grupos:
+${previewGroups}${selected.length > 8 ? "\n..." : ""}${remainingText}
+
+Confirma o envio?`,
+          footer: "Modo seguro: envio lento, com confirmação e cooldown.",
+          buttons
+        },
+        { quoted: msg }
+      );
+    } catch (err) {
+      await sock.sendMessage(from, { text: erros_prontos || "Deu ruim no announcement." }, { quoted: msg });
+      console.error("Erro no comando /annoucement:", err);
+    }
+  }
+};

--- a/src/commands/donos/announcement.js
+++ b/src/commands/donos/announcement.js
@@ -1,0 +1,6 @@
+const annoucement = require("./annoucement");
+
+module.exports = {
+  ...annoucement,
+  name: "announcement"
+};


### PR DESCRIPTION
## Resumo

Adicionei um comando de announcement para donos enviarem comunicados para os grupos cadastrados da Yuki com foco em segurança, controle e redução de risco de rate limit.

O comando não dispara mensagens imediatamente. Ele sempre cria um preview primeiro, exige confirmação manual e só depois inicia o envio em background com delays altos entre cada grupo.

## O que foi desenvolvido

### Novo comando `/announcement`

Permite que donos enviem um comunicado para os grupos registrados no banco da Yuki.

Fluxo principal:

1. O dono envia:

```bash
/announcement "texto do comunicado"
```

2. A Yuki monta um preview com:
- quantidade de grupos que receberão
- total de grupos cadastrados elegíveis
- delay mínimo e máximo entre envios
- prévia exata da mensagem
- primeiros grupos que vão receber
- aviso caso existam mais grupos do que o limite seguro do lote

3. A Yuki mostra botões:
- `Confirmar envio`
- `Cancelar`

4. Só após confirmação o envio começa.

5. O envio roda em background, com pausa pesada entre cada grupo.

## Segurança contra ban/rate limit

Esse comando foi feito de forma conservadora para evitar comportamento parecido com spam.

Medidas adicionadas:

- Apenas donos podem usar.
- Confirmação obrigatória antes de enviar.
- Delay padrão de `90s` a `180s` entre cada grupo.
- O primeiro envio também espera o primeiro delay.
- Limite padrão de `15` grupos por execução.
- Limite máximo hardcoded de `25` grupos por execução.
- Cooldown global de `30 minutos` entre announcements.
- Envio em background para não travar a Yuki.
- Logs no console para cada grupo enviado ou com falha.
- Se aparecer erro relacionado a rate limit, a Yuki faz uma pausa extra antes de continuar.
- O comando usa os grupos já registrados no MongoDB em vez de buscar grupos direto no WhatsApp.

## Dry-run

Também adicionei modo de teste sem envio real.

Uso:

```bash
/announcement --dry "texto do comunicado"
```

Esse modo mostra:
- quantos grupos receberiam
- delay configurado
- prévia da mensagem
- lista dos primeiros grupos selecionados
- aviso de limite de lote, se aplicável

Nenhuma mensagem é enviada nesse modo.

## Controle de lote

Por padrão, o comando envia para no máximo `15` grupos por execução.

Dá pra reduzir o lote manualmente:

```bash
/announcement --limit 10 "texto do comunicado"
```

Mesmo que alguém tente passar um valor alto, o comando trava no máximo em `25` grupos por segurança.

## Controle de delay

O delay padrão é pesado:

```txt
mínimo: 90 segundos
máximo: 180 segundos
```

Também dá pra configurar delays ainda maiores:

```bash
/announcement --min-delay 120 --max-delay 240 "texto do comunicado"
```

Existe uma trava mínima de segurança: o delay mínimo nunca fica abaixo de `60 segundos`.

## Status

Adicionei uma forma de conferir se existe announcement rodando:

```bash
/announcement status
```

Se tiver envio em andamento, a Yuki responde qual job está rodando. Se não tiver, ela avisa que não há nenhum announcement ativo.

## Cancelamento antes do envio

Enquanto o preview ainda não foi confirmado, o dono pode cancelar pelo botão `Cancelar`.

Se cancelar:
- nada é enviado
- o pending announcement é removido da memória
- a Yuki confirma o cancelamento

## Confirmação

Ao clicar em `Confirmar envio`, a Yuki:
- valida se o preview ainda existe
- valida se foi o mesmo dono que criou
- valida se não expirou
- valida se não existe outro announcement rodando
- valida cooldown de 30 minutos
- inicia o envio em background

O preview expira após `10 minutos`.

## Arquivos alterados

### `src/commands/donos/annoucement.js`

Arquivo principal do comando.

Inclui:
- parsing dos argumentos
- validação de dono
- montagem do preview
- dry-run
- controle de lote
- controle de delays
- confirmação
- cancelamento
- status
- envio em background
- cooldown global
- tratamento de falhas por grupo
- pausa extra em caso de rate limit

### `src/commands/donos/announcement.js`

Alias limpo para o comando principal `/announcement`.

## Como testar

### 1. Testar dry-run

```bash
/announcement --dry "teste seguro da yuki"
```

Resultado esperado:
- a Yuki mostra preview
- nenhum grupo recebe mensagem

### 2. Testar preview real

```bash
/announcement "teste real da yuki"
```

Resultado esperado:
- a Yuki mostra preview
- aparecem botões de confirmar e cancelar
- nada é enviado antes da confirmação

### 3. Testar cancelamento

Clique em `Cancelar`.

Resultado esperado:
- a Yuki confirma que cancelou
- nenhum grupo recebe mensagem

### 4. Testar envio confirmado

Rode novamente:

```bash
/announcement "teste real da yuki"
```

Clique em `Confirmar envio`.

Resultado esperado:
- a Yuki avisa que iniciou
- o primeiro envio só acontece depois do delay
- cada grupo recebe com intervalo entre `90s` e `180s`

### 5. Testar limite

```bash
/announcement --limit 3 "teste limitado"
```

Resultado esperado:
- apenas 3 grupos entram no lote

### 6. Testar delay customizado

```bash
/announcement --min-delay 120 --max-delay 240 "teste com delay maior"
```

Resultado esperado:
- preview mostra delay de 120s a 240s
- envio respeita esse intervalo

### 7. Testar status

```bash
/announcement status
```

Resultado esperado:
- se tiver envio rodando, mostra o job atual
- se não tiver, informa que não há announcement ativo

## Observações para o próximo contribuidor

Esse comando foi intencionalmente feito de forma conservadora.

Evitar:
- reduzir delay padrão
- remover confirmação
- aumentar limite máximo
- buscar grupos direto no WhatsApp durante o envio
- mandar para todos os grupos sem lote
- transformar o envio em loop rápido

Se precisar aumentar alcance, o ideal é fazer paginação/lotes manuais com cooldown entre eles, não remover as travas.
```