### PR TITLE
fix(tiktok): aceitei link curto no check e download

### DIFF
--- a/src/api/tiktok-api/app/parsers/video_parser.py
+++ b/src/api/tiktok-api/app/parsers/video_parser.py
@@ -5,6 +5,10 @@ from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger("video_parser")
+SHORT_TIKTOK_RE = re.compile(
+    r"^https?://(?:www\.)?(?:vm|vt)\.tiktok\.com/[A-Za-z0-9_-]+/?(?:[?#].*)?$",
+    re.IGNORECASE,
+)
 
 try:
     SAO_PAULO_TZ = ZoneInfo("America/Sao_Paulo")
@@ -25,6 +29,10 @@ def extract_video_id(url_or_id: str) -> str:
     if url_or_id.isdigit():
         return url_or_id
     raise ValueError(f"Could not extract id from '{url_or_id}'")
+
+
+def is_tiktok_short_url(url_or_id: str | None) -> bool:
+    return bool(SHORT_TIKTOK_RE.match(str(url_or_id or "").strip()))
 
 
 def _unique(values):

--- a/src/api/tiktok-api/app/routers/video.py
+++ b/src/api/tiktok-api/app/routers/video.py
@@ -7,7 +7,7 @@ from fastapi.responses import FileResponse, PlainTextResponse, StreamingResponse
 from starlette.background import BackgroundTask
 
 from app.formatters.text_panel import build_text_panel
-from app.parsers.video_parser import extract_video_id, parse_raw_info
+from app.parsers.video_parser import extract_video_id, is_tiktok_short_url, parse_raw_info
 from app.services.ytdlp import download_format, get_raw_info
 from app.services.tikwm import get_tikwm_info
 
@@ -104,14 +104,27 @@ def _select_download_candidates(data: dict, quality: str) -> list[dict]:
 
 
 def _resolve_input(url: str | None, video_id: str | None) -> str:
-    video_input = url or video_id
+    video_input = str(url or video_id or "").strip()
     if not video_input:
         raise HTTPException(status_code=400, detail="Missing 'url' or 'id'")
+    if is_tiktok_short_url(video_input):
+        return video_input
     try:
         extract_video_id(video_input)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return video_input
+
+
+def _resolved_video_id(raw: dict, fallback_input: str) -> str:
+    raw_id = str(raw.get("id") or "").strip()
+    if raw_id:
+        return raw_id
+
+    try:
+        return extract_video_id(raw.get("webpage_url") or fallback_input)
+    except ValueError:
+        return "tiktok"
 
 
 async def _stream_remote_url(file_url: str, media_type: str, filename: str, headers: dict) -> StreamingResponse:
@@ -156,6 +169,10 @@ async def _stream_remote_url(file_url: str, media_type: str, filename: str, head
     )
 
 
+def _resolved_tiktok_url(raw: dict, fallback_input: str) -> str:
+    return raw.get("webpage_url") or raw.get("original_url") or fallback_input
+
+
 @router.get("/info")
 async def video_info(
     url: str | None = Query(default=None, description="TikTok video URL"),
@@ -180,7 +197,7 @@ async def video_info(
         or (data.get("stats") or {}).get("downloads") is None
     )
     if needs_fallback:
-        tikwm = await get_tikwm_info(video_input)
+        tikwm = await get_tikwm_info(_resolved_tiktok_url(raw, video_input))
         if tikwm:
             data = await parse_raw_info(raw, tikwm=tikwm)
     if format == "text":
@@ -195,7 +212,6 @@ async def download_video(
     quality: str = Query(default="highest", description="highest, medium, audio or format_id"),
 ):
     video_input = _resolve_input(url, id)
-    vid = extract_video_id(video_input)
 
     try:
         raw = await get_raw_info(video_input)
@@ -205,8 +221,9 @@ async def download_video(
         logger.exception("Extraction error")
         raise HTTPException(status_code=502, detail=f"Extraction failed: {exc}") from exc
 
-    tikwm = await get_tikwm_info(video_input)
+    tikwm = await get_tikwm_info(_resolved_tiktok_url(raw, video_input))
     data = await parse_raw_info(raw, tikwm=tikwm)
+    vid = _resolved_video_id(raw, video_input)
 
     media_type = "video/mp4"
     filename = f"{vid}_video.mp4"

--- a/src/api/tiktok-api/app/services/tikwm.py
+++ b/src/api/tiktok-api/app/services/tikwm.py
@@ -20,7 +20,14 @@ def _cache_key(video_id: str) -> str:
 async def get_tikwm_info(video_id_or_url: str) -> dict | None:
     from app.parsers.video_parser import extract_video_id
 
-    vid = extract_video_id(video_id_or_url)
+    try:
+        vid = extract_video_id(video_id_or_url)
+    except ValueError:
+        vid = str(video_id_or_url or "").strip()
+
+    if not vid:
+        return None
+
     key = _cache_key(vid)
     if key in cache:
         logger.debug("Cache hit for %s", vid)

--- a/src/api/tiktok-api/app/services/ytdlp.py
+++ b/src/api/tiktok-api/app/services/ytdlp.py
@@ -41,6 +41,22 @@ def extract_info_sync(video_id_or_url: str) -> dict:
     with YoutubeDL(YDL_OPTS) as ydl:
         return ydl.extract_info(video_id_or_url, download=False)
 
+def _cache_key(video_id_or_url: str) -> str:
+    from app.parsers.video_parser import extract_video_id
+
+    value = str(video_id_or_url or "").strip()
+    try:
+        return extract_video_id(value)
+    except ValueError:
+        return value
+
+def _store_cache(primary_key: str, info: dict) -> None:
+    cache[primary_key] = info
+
+    resolved_id = str(info.get("id") or "").strip()
+    if resolved_id and resolved_id != primary_key:
+        cache[resolved_id] = info
+
 def download_format_sync(video_id_or_url: str, format_id: str | None) -> dict:
     temp_dir = tempfile.mkdtemp(prefix="tiktok-api-")
     output_template = os.path.join(temp_dir, "%(id)s-%(format_id)s.%(ext)s")
@@ -75,19 +91,18 @@ def download_format_sync(video_id_or_url: str, format_id: str | None) -> dict:
         raise
 
 async def get_raw_info(video_id_or_url: str) -> dict:
-    from app.parsers.video_parser import extract_video_id
-    vid = extract_video_id(video_id_or_url)
-    if vid in cache:
-        logger.debug(f"Cache hit for {vid}")
-        return cache[vid]
+    key = _cache_key(video_id_or_url)
+    if key in cache:
+        logger.debug(f"Cache hit for {key}")
+        return cache[key]
 
-    logger.info(f"Extracting {vid}")
+    logger.info(f"Extracting {key}")
     try:
         info = await asyncio.wait_for(
             asyncio.to_thread(extract_info_sync, video_id_or_url),
             timeout=settings.YTDLP_TIMEOUT
         )
-        cache[vid] = info
+        _store_cache(key, info)
         return info
     except asyncio.TimeoutError:
         logger.error(f"Timeout for {video_id_or_url}")


### PR DESCRIPTION
## o que mexi

Arrumei o fluxo da API do TikTok pra aceitar link curto (`vt.tiktok.com`/`vm.tiktok.com`) tanto no `/check` quanto no `/download`.

O bug era que a API barrava o link antes do `yt-dlp` resolver o redirect.

## mudanças

- API reconhece link curto do TikTok sem devolver `400 Bad Request`.
- `yt-dlp` agora pode receber o link curto direto e resolver o vídeo real.
- Cache guarda o resultado pelo link recebido e também pelo ID real quando o `yt-dlp` resolve.
- TikWM usa a URL resolvida quando disponível e não derruba fallback em link curto.
- `/download` pega o ID real só depois da extração.

## testes

- `python -m py_compile ...`
- `/video/info` com `https://vt.tiktok.com/ZSxdcSbNj/` retornou `200`
- `/video/download?quality=normal` retornou `200`, `video/mp4` e iniciou stream corretamente

## observação

Os erros `not-authorized` e `participantUp.js split` dos logs são de grupo/moderação da Yuki, não do TikTok.