### PR TITLE
fix(tiktok): resolvi shortlink antes do yt-dlp

### DIFF
--- a/src/api/tiktok-api/app/routers/video.py
+++ b/src/api/tiktok-api/app/routers/video.py
@@ -8,6 +8,7 @@ from starlette.background import BackgroundTask
 
 from app.formatters.text_panel import build_text_panel
 from app.parsers.video_parser import extract_video_id, is_tiktok_short_url, parse_raw_info
+from app.services.tiktok_url import resolve_tiktok_url
 from app.services.ytdlp import download_format, get_raw_info
 from app.services.tikwm import get_tikwm_info
 
@@ -180,6 +181,7 @@ async def video_info(
     format: str = Query(default="json", description="json or text"),
 ):
     video_input = _resolve_input(url, id)
+    video_input = await resolve_tiktok_url(video_input)
 
     try:
         raw = await get_raw_info(video_input)
@@ -212,6 +214,7 @@ async def download_video(
     quality: str = Query(default="highest", description="highest, medium, audio or format_id"),
 ):
     video_input = _resolve_input(url, id)
+    video_input = await resolve_tiktok_url(video_input)
 
     try:
         raw = await get_raw_info(video_input)

--- a/src/api/tiktok-api/app/services/tiktok_url.py
+++ b/src/api/tiktok-api/app/services/tiktok_url.py
@@ -1,0 +1,34 @@
+import logging
+
+import aiohttp
+
+from app.parsers.video_parser import is_tiktok_short_url
+
+logger = logging.getLogger("tiktok_url")
+
+SHORT_URL_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Connection": "keep-alive",
+}
+
+
+async def resolve_tiktok_url(url_or_id: str) -> str:
+    video_input = str(url_or_id or "").strip()
+    if not is_tiktok_short_url(video_input):
+        return video_input
+
+    timeout = aiohttp.ClientTimeout(total=12, sock_connect=5, sock_read=7)
+    try:
+        async with aiohttp.ClientSession(headers=SHORT_URL_HEADERS, timeout=timeout) as session:
+            async with session.get(video_input, allow_redirects=True, max_redirects=6) as response:
+                resolved = str(response.url)
+                if resolved and resolved != video_input:
+                    logger.info("Resolved short TikTok URL: %s -> %s", video_input, resolved)
+                    return resolved
+    except Exception as exc:
+        logger.warning("Could not resolve TikTok short URL %s: %s", video_input, exc)
+
+    return video_input


### PR DESCRIPTION
## update de agora

Corrigi o erro novo dos links curtos que estavam dando `502 Bad Gateway` na host.

O problema não era mais validação da API. A API já aceitava `vt.tiktok.com`, mas o `yt-dlp` tentava resolver esse shortlink direto pelo extractor `vm.tiktok` e a SquareCloud recebia `403 Forbidden`.

Agora a API faz um passo antes:
- se receber `vt.tiktok.com` ou `vm.tiktok.com`, resolve o redirect com headers de navegador;
- transforma em URL completa do TikTok;
- só depois chama `yt-dlp`, TikWM e download.

## teste

Testado com:

`https://vt.tiktok.com/ZSxdc9VM6/`

Resultado:
- `/video/info` retornou `200`
- `/video/download?quality=normal` retornou `200`
- o shortlink resolveu para o vídeo `7632023790687456520`
- o download abriu stream `video/mp4`