### PR TITLE
fix(mongo): reduz queries no fluxo de mensagens

### DIFF
--- a/src/backend/controllers/user/discordAuth.js
+++ b/src/backend/controllers/user/discordAuth.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 const socket = require("../../../sock.js");
 const { clientRedis } = require("../../../lib/redis.js");
-const { users } = require("../../../database/models/users.js");
+const { updateUserAndCache } = require("../../../utils/dbHelpers.js");
 
 
 module.exports = async (req, res) => {
@@ -43,7 +43,7 @@ module.exports = async (req, res) => {
             }
         });
 
-        await users.updateOne({userLid: user.userLid}, {$set: {discord_id: user_response.data.id, discord_name: user_response.data.global_name}}, {upsert: true});
+        await updateUserAndCache(user.userLid, {$set: {discord_id: user_response.data.id, discord_name: user_response.data.global_name}}, {upsert: true});
 
         try {
             

--- a/src/backend/controllers/user/setName.js
+++ b/src/backend/controllers/user/setName.js
@@ -1,5 +1,5 @@
-const { users } = require("../../../database/models/users.js");
 const jwt = require("jsonwebtoken");
+const { updateUserAndCache } = require("../../../utils/dbHelpers.js");
 
 module.exports = async (req, res) => {
 const user = req?.cookies?.user;
@@ -13,7 +13,7 @@ return;
 
 const jwtsender = jwt.verify(user, process.env.SECRET);
 
-await users.updateOne({userLid: jwtsender.sender}, {$set: {name: nome}}, {upsert: true});
+await updateUserAndCache(jwtsender.sender, {$set: {name: nome}}, {upsert: true, name: nome});
 
 res.status(200).json({message: "nome trocado com sucesso!"});
 

--- a/src/backend/controllers/user/userInfo.js
+++ b/src/backend/controllers/user/userInfo.js
@@ -1,5 +1,4 @@
 const { users } = require("../../../database/models/users.js");
-const jwt = require("jsonwebtoken");
 
 const info = async (req, res) => {
 const user = req?.query?.user;
@@ -11,7 +10,7 @@ res.status(404).json({error: "usuario nao registrado ou encontrado."});
 return;
 }
 
-const userdb = await users.findOne({discord_id: token.sender});
+const userdb = await users.findOne({discord_id: user}).lean();
 
 res.status(200).json({userdb});
 

--- a/src/backend/routes/user.js
+++ b/src/backend/routes/user.js
@@ -1,4 +1,3 @@
-const { users } = require("../../database/models/users.js");
 const login = require("../controllers/user/login.js");
 const express = require("express");
 const router = express.Router();

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -1,14 +1,16 @@
 const express = require("express");
 const { clientRedis } = require("../lib/redis.js");
 const { payment } = require("../lib/mercadoPago.js");
-const { grupos } = require("../database/models/grupos.js");
 const { numberOwner } = require("../config.js");
 const axios = require("axios");
-const { users } = require("../database/models/users.js");
+const { getUserCached, updateGroupAndCache, updateUserAndCache } = require("../utils/dbHelpers.js");
 const userRouter = require("./routes/user.js");
 const cors = require("cors");
 const cookieParser = require("cookie-parser")
 const catbox = require("./controllers/user/catbox.js");
+
+let activeSock = null;
+let httpServer = null;
 
 async function refreshToken(token, user) {
   try {
@@ -21,7 +23,7 @@ async function refreshToken(token, user) {
         "Content-Type": "application/x-www-form-urlencoded",
         "Authorization": "Basic " + Buffer.from(process.env.CLIENT_SPOTIFY + ":" + process.env.SPOTIFY_KEY).toString("base64")}});
         
-        await users.updateOne({userLid: user}, {$set: {"spotifyToken.token": response.data.access_token}}, {upsert: true});
+        await updateUserAndCache(user, {$set: {"spotifyToken.token": response.data.access_token}}, {upsert: true});
         
         console.log(`token resetado para: ${response.data.access_token}`);
         
@@ -33,6 +35,12 @@ async function refreshToken(token, user) {
 }
 
 module.exports = async function server(sock) {
+  activeSock = sock;
+
+  if (httpServer) {
+    console.log("[backend] socket atualizado; servidor HTTP ja estava ativo");
+    return httpServer;
+  }
   
   const app = express();
   
@@ -84,18 +92,18 @@ next()
           const diasTimestamp = 1000 * 24 * 60 * 60 * Number(aluguel.dias);
           
           //adiciona os dias;
-          await grupos.updateOne({groupId: aluguel.groupId}, {$set: {aluguel: Date.now() + diasTimestamp}}, {upsert: true});
+          await updateGroupAndCache(aluguel.groupId, {$set: {aluguel: Date.now() + diasTimestamp}});
           
           
           try {
-          const metadataGroup = await sock.groupMetadata(aluguel.groupId);
+          const metadataGroup = await activeSock.groupMetadata(aluguel.groupId);
           
-          await sock.sendMessage(aluguel.user, {text: `🥳Pagamento concluído! ${aluguel.dias} dias serão adicionando ao grupo: ${metadataGroup.subject} 🎉`});
+          await activeSock.sendMessage(aluguel.user, {text: `🥳Pagamento concluído! ${aluguel.dias} dias serão adicionando ao grupo: ${metadataGroup.subject} 🎉`});
           
             
-          await sock.sendMessage(aluguel.groupId, {text: `O @${aluguel.user.split("@")[0]} patrocinou o aluguel da yuki pra galera! 🥳🎉`, mentions: [aluguel.user]});
+          await activeSock.sendMessage(aluguel.groupId, {text: `O @${aluguel.user.split("@")[0]} patrocinou o aluguel da yuki pra galera! 🥳🎉`, mentions: [aluguel.user]});
           
-          await sock.sendMessage(numberOwner, {text: `Pagamento concluido🎉\nNome: ${aluguel.user.split("@")[0]}\nGrupo:${metadataGroup.subject}\nvalor: ${aluguel.valor}\ndias: ${aluguel.dias}`, mentions: [aluguel.user]});
+          await activeSock.sendMessage(numberOwner, {text: `Pagamento concluido🎉\nNome: ${aluguel.user.split("@")[0]}\nGrupo:${metadataGroup.subject}\nvalor: ${aluguel.valor}\ndias: ${aluguel.dias}`, mentions: [aluguel.user]});
           
           }
           catch(err) {
@@ -155,11 +163,11 @@ next()
       Authorization: "Basic " + Buffer.from(process.env.CLIENT_SPOTIFY + ":" + process.env.SPOTIFY_KEY).toString("base64")
     }});
     
-    await users.updateOne({userLid: user.userLid}, {$set: {spotifyToken: {refresh: response.data.refresh_token, token: response.data.access_token}}}, {upsert: true});
+    await updateUserAndCache(user.userLid, {$set: {spotifyToken: {refresh: response.data.refresh_token, token: response.data.access_token}}}, {upsert: true});
     
     res.status(200).send("ok, pode voltar para o whatsapp.");
     
-    await sock.sendMessage(user.userLid, {text: "Spotify conectado com sucesso!"});
+    await activeSock.sendMessage(user.userLid, {text: "Spotify conectado com sucesso!"});
     
     }
     catch(err) {
@@ -177,7 +185,7 @@ next()
         return
       }
       
-      const userDb = await users.findOne({userLid: user});
+      const userDb = await getUserCached(user);
       
       if(!userDb) {
         res.status(404).send("Usuário não encontrado.");
@@ -186,7 +194,7 @@ next()
       
       let token = userDb?.spotifyToken?.token;
       
-      const refresh = userDb?.spotifyToken?.refresh_token;
+      const refresh = userDb?.spotifyToken?.refresh;
       
       let response;
        
@@ -247,7 +255,7 @@ next()
         return;
       }
       
-      await sock.sendMessage(from, {text: message});
+      await activeSock.sendMessage(from, {text: message});
       
       res.status(200).send("mensagem enviada com sucesso!");
       
@@ -264,9 +272,13 @@ next()
   
   
   
-  app.listen(port, () => {
+  httpServer = app.listen(port, () => {
     console.log(`Backend iniciado em: http://localhost:${port}`);
   });
+  httpServer.on("error", (err) => {
+    console.error("[backend] erro no servidor HTTP:", err);
+  });
+  return httpServer;
   
   
 }

--- a/src/commands/admin/add.js
+++ b/src/commands/admin/add.js
@@ -1,38 +1,26 @@
-const { numberOwner, numberBot } = require("../../config");
-const { donos } = require("../../database/models/donos");
+const { getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "add",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      
-      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-  
-     const metadados = await sock.groupMetadata(from);
-     
-     const Admins = metadados.participants.filter(p => p.admin);
-  const groupAdmins = Admins.map(m => m.lid);
-  const donin = await donos.findOne({userLid: sender});
-  
-  
-  if(!groupAdmins.includes(sender) && !donin) {
-await sock.sendMessage(from, {text: "Comandos para admins."}, {quoted: msg});
-return
-  }
-  
-  if(!mention) {
-    await sock.sendMessage(from, {text: "Menciona alguém zé bct."}, {quoted: msg});
-    return
-  }
-    
-    await sock.groupParticipantsUpdate(from, [mention], "add");
-      
-    }
-    catch(err) {
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+      const { allowed } = await getGroupPermission(sock, from, sender);
+
+      if(!allowed) {
+        await sock.sendMessage(from, {text: "Comandos para admins."}, {quoted: msg});
+        return;
+      }
+
+      if(!mention) {
+        await sock.sendMessage(from, {text: "Menciona alguém zé bct."}, {quoted: msg});
+        return;
+      }
+
+      await sock.groupParticipantsUpdate(from, [mention], "add");
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
-      console.error(err)
+      console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/admin/adv.js
+++ b/src/commands/admin/adv.js
@@ -1,65 +1,45 @@
 const { advertidos } = require("../../database/models/adverts");
-
-const { donos } = require("../../database/models/donos");
+const { getGroupPermission, isOwnerCached } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "adv",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      const metadata = await sock.groupMetadata(from);
-      
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-      
-      const doninhos = await donos.findOne({userLid: mention});
-      
-      const doninhoSender = await donos.findOne({userLid: sender});
-      
-      if(!isAdmin.includes(sender) && !doninhos) {
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+      const { allowed } = await getGroupPermission(sock, from, sender);
+
+      if(!allowed) {
         await sock.sendMessage(from, {text: "TU É ADMIN?! FILHO DA PUTA!"}, {quoted: msg});
-        return
+        return;
       }
-      
-      
-      
+
       if(!mention) {
         await sock.sendMessage(from, {text: "Pelo amor de Deus... Marca alguém seu lixo!"}, {quoted: msg});
-        return
+        return;
       }
-      
-      
-      
-      if(doninhos) {
+
+      if(await isOwnerCached(mention)) {
         await sock.sendMessage(from, {text: "Tentar advertir um dono é igual um velho tentando fuder. Nunca funciona"}, {quoted: msg});
-        return
+        return;
       }
-      
-      
-      
-      const advUpdate = await advertidos.findOneAndUpdate({userLid: mention, grupo: from}, {$inc: {adv: 1}}, {new: true, upsert: true});
-      
+
+      const advUpdate = await advertidos.findOneAndUpdate(
+        {userLid: mention, grupo: from},
+        {$inc: {adv: 1}},
+        {new: true, upsert: true, setDefaultsOnInsert: true}
+      );
+
       await sock.sendMessage(from, {text: "Advertência adicionada com sucesso!"}, {quoted: msg});
-      
       await sock.sendMessage(from, {text: `@${advUpdate.userLid.split("@")[0]}, você foi advertido. Agora possui ${advUpdate.adv}, se chegar a 3 será expulso.`, mentions: [advUpdate.userLid]}, {quoted: msg});
-      
+
       if(advUpdate.adv >= 3) {
         await sock.sendMessage(from, {text: "Membro expulso por ter 3 ou mais advertências!"}, {quoted: msg});
-        
         await sock.groupParticipantsUpdate(from, [mention], "remove");
-        
         await advertidos.deleteOne({userLid: mention, grupo: from});
-        
       }
-      
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/admin/ban.js
+++ b/src/commands/admin/ban.js
@@ -1,5 +1,5 @@
 const { numberBot } = require("../../config");
-const { donos } = require("../../database/models/donos");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 const { isOwnerLid } = require("../../utils/owner");
 
 module.exports = {
@@ -12,10 +12,10 @@ module.exports = {
 
       const metadados = await sock.groupMetadata(from);
       const admins = metadados.participants.filter((p) => p.admin);
-      const groupAdmins = admins.map((m) => m.lid);
-      const donin = await donos.findOne({ userLid: sender });
+      const groupAdmins = admins.flatMap((m) => [m.lid, m.id]).filter(Boolean);
+      const isSubOwner = await isOwnerCached(sender);
 
-      if (!groupAdmins.includes(sender) && !donin) {
+      if (!groupAdmins.includes(sender) && !isSubOwner) {
         const mensagensTentativaSemPerm = [
           `${msg.pushName}, tu não tem cargo pra isso, mano. Vai brincar de moderador em outro lugar.`,
           `Tentou banir sem permissão. O ego tá grande, mas o poder é zero.`,
@@ -61,7 +61,7 @@ module.exports = {
         return;
       }
 
-      if (await donos.findOne({ userLid: mention })) {
+      if (await isOwnerCached(mention)) {
         await sock.sendMessage(from, { text: "Ele é um dos meus donos especiais, não pode ser banido!" }, { quoted: msg });
         return;
       }

--- a/src/commands/admin/delete.js
+++ b/src/commands/admin/delete.js
@@ -1,51 +1,33 @@
-const { donos } = require("../../database/models/donos");
+const { getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "d",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      const msgquoted = msg.message.extendedTextMessage.contextInfo
-      
-      
-      
-      const metadata = await sock.groupMetadata(from);
-      
-      const ListAdmins = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      const donoo = await donos.findOne({userLid: sender})
-      
-      if(!ListAdmins.includes(sender) && !donoo) {
-        await sock.sendMessage(from, {text: "Comando exlusivo de admins!"}, {quoted: msg});
-        return
-      }
-      
-      
-       await sock.sendMessage(from, {delete: {
-         remoteJid: from,
-         fromMe: false,
-         id: msgquoted.stanzaId,
-         participant: msgquoted.participant || undefined
-       }});
-       
+      const msgquoted = msg.message.extendedTextMessage.contextInfo;
+      const { allowed } = await getGroupPermission(sock, from, sender);
 
-      
-    }
-    catch(err) {
-      
-      const msgError = String(err);
-      
-      if(msgError.includes("forbiden")) {
-        
-        await sock.sendMessage(from, {text: "Não possuo admin para apagar mensagens."}, {quoted: msg});
-        return
+      if(!allowed) {
+        await sock.sendMessage(from, {text: "Comando exlusivo de admins!"}, {quoted: msg});
+        return;
       }
-      
-      
+
+      await sock.sendMessage(from, {delete: {
+        remoteJid: from,
+        fromMe: false,
+        id: msgquoted.stanzaId,
+        participant: msgquoted.participant || undefined
+      }});
+    } catch(err) {
+      const msgError = String(err);
+
+      if(msgError.includes("forbiden")) {
+        await sock.sendMessage(from, {text: "Não possuo admin para apagar mensagens."}, {quoted: msg});
+        return;
+      }
+
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
   }
-  
-}
+};

--- a/src/commands/admin/grupo.js
+++ b/src/commands/admin/grupo.js
@@ -1,9 +1,8 @@
-const { donos } = require("../../database/models/donos");
+const { getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "grupo",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-    
     async function sendHelp() {
       await sock.sendMessage(from, {text: `*Como mudar estados de um grupo com a Yuki:*
 > Ao usar /grupo deve-se usar um parâmetro de algum estado que deseja pôr no grupo.
@@ -15,58 +14,42 @@ module.exports = {
 
 Fácil de usar, né? Não? Então você possui algum tipo de deficiência mental.`}, {quoted: msg});
     }
+
     try {
-      
-      const metadata = await sock.groupMetadata(from);
-      
-      const admin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const donoSender = await donos.findOne({userLid: sender});
-      
-      if(!admin.includes(sender) && !donoSender) {
+      const { allowed } = await getGroupPermission(sock, from, sender);
+
+      if(!allowed) {
         await sock.sendMessage(from, {text: "Tu é admin? Seu merda."}, {quoted: msg});
-        return
+        return;
       }
-      
+
       const parametro = args?.[0]?.trim();
-      
+
       if(!parametro) {
         await sendHelp();
-        return
+        return;
       }
-      
+
       if(parametro === "f") {
-        await sock.groupSettingUpdate(from, 'announcement');
-        return
-       }
-      
+        await sock.groupSettingUpdate(from, "announcement");
+        return;
+      }
+
       if(parametro === "a") {
         await sock.groupSettingUpdate(from, "not_announcement");
-        return
+        return;
       }
-      
-      else {
-        await sendHelp();
-        return
-      }
-      
-    }
-    catch(err) {
+
+      await sendHelp();
+    } catch(err) {
       const debug = String(err);
-      
+
       if(debug.includes("forbidden")) {
         await sock.sendMessage(from, {text: "Não possuo admin."}, {quoted: msg});
       }
-      
+
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
-      
-      console.error(err)
-      
+      console.error(err);
     }
-    
-    
   }
-  
-}
+};

--- a/src/commands/admin/mute.js
+++ b/src/commands/admin/mute.js
@@ -1,6 +1,6 @@
 const { mutados } = require("../../database/models/mute");
-const { donos } = require("../../database/models/donos");
 const { numberBot } = require("../../config");
+const { getGroupPermission, isOwnerCached, setMuteCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "mute",
@@ -8,65 +8,48 @@ module.exports = {
     async function reply(texto) {
       await sock.sendMessage(from, {text: texto}, {quoted: msg});
     }
-    
+
     try {
-      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-      
-      const metadata = await sock.groupMetadata(from);
-      
-      const admins = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      const donoSender = await donos.findOne({userLid: sender});
-      
-      
-      if(!admins.includes(sender) && !donoSender) {
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+      const { allowed } = await getGroupPermission(sock, from, sender);
+
+      if(!allowed) {
         await reply("Você n é admin, zé bct");
-        return
+        return;
       }
-      
+
       if(!mention) {
         await reply("Mencione quem deseja mutar.");
-        return
+        return;
       }
-      
-      const isdono = await donos.findOne({userLid: mention});
-      
-      if(isdono) {
+
+      if(await isOwnerCached(mention)) {
         await reply("Muta subdono n seu miseravel");
-        return
+        return;
       }
-      
+
       if(mention.includes(numberBot)) {
         await reply("Vai me mutar não seu lixo!");
-        return
+        return;
       }
-      
-      /*if(mention.includes(admins)) {
-        await reply("Posso mutar adm não seu lixo.");
-        return
-      }
-      */
-      
-      const ismute = await mutados.findOne({userLid: mention});
-      
-      if(ismute) {
+
+      const mute = await mutados.findOneAndUpdate(
+        {userLid: mention, grupo: from},
+        {$setOnInsert: {userLid: mention, grupo: from}},
+        {upsert: true, new: false}
+      );
+
+      if(mute) {
+        setMuteCache(mention, from, mute.toObject?.() || mute);
         await reply("Este usuário já está mutado.");
-        return
+        return;
       }
-      
-      await mutados.create({userLid: mention, grupo: from});
-      
+
+      setMuteCache(mention, from, {userLid: mention, grupo: from, tentativasMsg: 0});
       await reply("Usuário mutado com sucesso! Caso mande mais de 3 mensagens será removido.");
-      
-    }
-    catch(err) {
+    } catch(err) {
       await reply(erros_prontos);
-      return
+      console.error(err);
     }
-    
-    
-    
-    
   }
-}
+};

--- a/src/commands/admin/promover.js
+++ b/src/commands/admin/promover.js
@@ -1,58 +1,40 @@
-const { donos } = require("../../database/models/donos");
-
+const { getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "promover",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      
-      const subDonu = await donos.findOne({userLid: sender})
-      
-      const metadados = await sock.groupMetadata(from);
-     
-     const Admins = metadados.participants.filter(p => p.admin);
-  const groupAdmins = Admins.map(m => m.lid);
-  
-  const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-  
-  if(!groupAdmins.includes(sender) && !subDonu) {
-    await sock.sendMessage(from, {text: "Vai tomar no seu cu, seu filho da puta"}, {quoted: msg});
-    return
-  }
-  
-  if(!mention) {
-    await sock.sendMessage(from, {text: "Marca alguém filho da puta"}, {quoted: msg});
-    return
-  }
-  
-  if(groupAdmins.includes(mention)) {
-    await sock.sendMessage(from, {text: "Esse usuário já é admin, vsfd, lixo"}, {quoted: msg});
-    return
-  }
-  
-  
-    await sock.groupParticipantsUpdate(from, [mention], 'promote')
-    
-    await sock.sendMessage(from, {text: "Membro promovido com sucesso!"}, {quoted: msg});
-  
-      
-    }
-    catch(err) {
-      
-      const ifError = String(err);
-      
-      if(ifError.includes("forbidden")) {
-        await sock.sendMessage(from, {text: 'Não tenho admin seu filho da puta'}, {quoted: msg});
-        return
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
+      const groupAdmins = metadata.participants.filter(p => p.admin).flatMap(m => [m.lid, m.id]).filter(Boolean);
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+
+      if(!allowed) {
+        await sock.sendMessage(from, {text: "Vai tomar no seu cu, seu filho da puta"}, {quoted: msg});
+        return;
       }
-      
+
+      if(!mention) {
+        await sock.sendMessage(from, {text: "Marca alguém filho da puta"}, {quoted: msg});
+        return;
+      }
+
+      if(groupAdmins.includes(mention)) {
+        await sock.sendMessage(from, {text: "Esse usuário já é admin, vsfd, lixo"}, {quoted: msg});
+        return;
+      }
+
+      await sock.groupParticipantsUpdate(from, [mention], "promote");
+      await sock.sendMessage(from, {text: "Membro promovido com sucesso!"}, {quoted: msg});
+    } catch(err) {
+      const ifError = String(err);
+
+      if(ifError.includes("forbidden")) {
+        await sock.sendMessage(from, {text: "Não tenho admin seu filho da puta"}, {quoted: msg});
+        return;
+      }
+
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
-    
-    
   }
-  
-}
+};

--- a/src/commands/admin/rebaixar.js
+++ b/src/commands/admin/rebaixar.js
@@ -1,57 +1,40 @@
-const { donos } = require("../../database/models/donos");
-
+const { getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "rebaixar",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      
-      const subDonu = await donos.findOne({userLid: sender})
-      
-      const metadados = await sock.groupMetadata(from);
-     
-     const Admins = metadados.participants.filter(p => p.admin);
-  const groupAdmins = Admins.map(m => m.lid);
-  
-  const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-  
-  if(!groupAdmins.includes(sender) && !subDonu) {
-    await sock.sendMessage(from, {text: "Vai tomar no seu cu, seu filho da puta"}, {quoted: msg});
-    return
-  }
-  
-  if(!mention) {
-    await sock.sendMessage(from, {text: "Marca alguém filho da puta"}, {quoted: msg});
-    return
-  }
-  
-  if(!groupAdmins.includes(mention)) {
-    await sock.sendMessage(from, {text: "Esse usuário não é admin, porra"}, {quoted: msg});
-    return
-  }
-  
-  
-    await sock.groupParticipantsUpdate(from, [mention], 'demote')
-    
-    await sock.sendMessage(from, {text: "Membro rebaixado com sucesso!"}, {quoted: msg});
-  
-      
-    }
-    catch(err) {
-      const ifError = String(err);
-      
-      if(ifError.includes("forbidden")) {
-        await sock.sendMessage(from, {text: 'Não tenho admin seu filho da puta'}, {quoted: msg});
-        return
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
+      const groupAdmins = metadata.participants.filter(p => p.admin).flatMap(m => [m.lid, m.id]).filter(Boolean);
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+
+      if(!allowed) {
+        await sock.sendMessage(from, {text: "Vai tomar no seu cu, seu filho da puta"}, {quoted: msg});
+        return;
       }
-      
+
+      if(!mention) {
+        await sock.sendMessage(from, {text: "Marca alguém filho da puta"}, {quoted: msg});
+        return;
+      }
+
+      if(!groupAdmins.includes(mention)) {
+        await sock.sendMessage(from, {text: "Esse usuário não é admin, porra"}, {quoted: msg});
+        return;
+      }
+
+      await sock.groupParticipantsUpdate(from, [mention], "demote");
+      await sock.sendMessage(from, {text: "Membro rebaixado com sucesso!"}, {quoted: msg});
+    } catch(err) {
+      const ifError = String(err);
+
+      if(ifError.includes("forbidden")) {
+        await sock.sendMessage(from, {text: "Não tenho admin seu filho da puta"}, {quoted: msg});
+        return;
+      }
+
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
-    
-    
   }
-  
-}
+};

--- a/src/commands/admin/rmAdv.js
+++ b/src/commands/admin/rmAdv.js
@@ -1,47 +1,38 @@
 const { advertidos } = require("../../database/models/adverts");
-
-const { donos } = require("../../database/models/donos");
+const { getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "rmadv",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      const metadata = await sock.groupMetadata(from);
-      
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-      
-      const doninhos = await donos.findOne({userLid: sender});
-      
-      if(!isAdmin.includes(sender) && !doninhos) {
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+      const { allowed } = await getGroupPermission(sock, from, sender);
+
+      if(!allowed) {
         await sock.sendMessage(from, {text: "TU É ADMIN?! FILHO DA PUTA!"}, {quoted: msg});
-        return
+        return;
       }
-      
+
       if(!mention) {
         await sock.sendMessage(from, {text: "Pelo amor de Deus... Marca alguém seu lixo!"}, {quoted: msg});
-        return
+        return;
       }
-      
-      const userAdv = await advertidos.findOne({userLid: mention, grupo: from});
-      
-      if(!userAdv || userAdv.adv <=0) {
+
+      const advRemovido = await advertidos.findOneAndUpdate(
+        {userLid: mention, grupo: from, adv: {$gt: 0}},
+        {$inc: {adv: -1}},
+        {new: true}
+      );
+
+      if(!advRemovido) {
         await sock.sendMessage(from, {text: "Esse usuário não possui advertências."}, {quoted: msg});
-        return
+        return;
       }
-      
-      const advRemovido = await advertidos.findOneAndUpdate({userLid: mention, grupo: from}, {$inc: {adv: -1}}, {new: true});
-      
-      
+
       await sock.sendMessage(from, {text: `Advertência removida com sucesso! Agora @${advRemovido.userLid.split("@")[0]} possui ${advRemovido.adv} advertências.`, mentions: [mention]}, {quoted: msg});
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
-      console.error(err)
+      console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/admin/roletaRussa.js
+++ b/src/commands/admin/roletaRussa.js
@@ -1,61 +1,47 @@
 const { donos } = require("../../database/models/donos");
+const { getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "roletarussa",
-  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+  async execute(sock, msg, from, args, erros_prontos) {
     try {
-      const metadata = await sock.groupMetadata(from);
-      
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-    
-      
-      
-      const donosSender = await donos.findOne({userLid: sender})
-      
       if(from.endsWith("@lid")) {
         await sock.sendMessage(from, {text: "Usa essa porra em grupo"}, {quoted: msg});
-        return
+        return;
       }
-      
-      if(!isAdmin.includes(sender) && !donosSender) {
+
+      const { metadata, allowed } = await getGroupPermission(sock, from, msg.key.participantLid || msg.key.participant);
+
+      if(!allowed) {
         await sock.sendMessage(from, {text: "Tu é admin? Seu merda."}, {quoted: msg});
-        return
+        return;
       }
-      
-      const donosTotais = await donos.find();
-      
-      const donosLid = donosTotais.map(d => d.userLid);
-      
+
+      const donosTotais = await donos.find().lean();
+      const donosLid = new Set(donosTotais.map(d => d.userLid));
+
       const members = metadata.participants.filter(p => {
-        
-        const admins = p.admin
-        
-        const isDono = donosLid.includes(p.id);
-        
-        return !admins && !isDono
+        const isDono = donosLid.has(p.id) || donosLid.has(p.lid);
+        return !p.admin && !isDono;
       }).map(p => p.id);
-      
-      
+
       const memberRandom = members[Math.floor(Math.random() * members.length)];
-      
+
       await sock.sendMessage(from, {text: `@${memberRandom.split("@")[0]}... Você foi o sorteado...`, mentions: [memberRandom]}, {quoted: msg});
-      
+
       setTimeout(async () => {
         await sock.groupParticipantsUpdate(from, [memberRandom], "remove");
       }, 3000);
-    }
-    catch(err) {
-      
+    } catch(err) {
       const errString = String(err);
-      
       console.error(err);
-      
+
       if(errString.includes("forbidden")) {
         await sock.sendMessage(from, {text: "Cadê meu adm? Seu lixo"}, {quoted: msg});
-        return
+        return;
       }
-      
+
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
     }
   }
-}
+};

--- a/src/commands/admin/totag.js
+++ b/src/commands/admin/totag.js
@@ -1,106 +1,71 @@
-const { downloadMediaMessage } = require('whaileys');
-const { donos } = require("../../database/models/donos");
-const { grupos } = require("../../database/models/grupos.js");
+const { downloadMediaMessage } = require("whaileys");
+const { ensureGroup, getGroupPermission } = require("../../utils/dbHelpers");
 
 module.exports = {
+  name: "totag",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    const texto = args.slice(0).join(" ")?.trim();
+    const { metadata, allowed } = await getGroupPermission(sock, from, sender);
 
-name: "totag",
-async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-  
-  const texto = args.slice(0).join(" ")?.trim();
-  
-  const metadados = await sock.groupMetadata(from);
-  
-  const Admins = metadados.participants.filter(p => p.admin)
-  const groupAdmins = Admins.map(m => m.lid)
-  
-  
-  const button = [
-    {buttonId: `${process.env.PREFIXO}afkmode 1`, buttonText: {displayText: "😴𝐒𝐢𝐥𝐞𝐧𝐜𝐢𝐚𝐫"}, type: 1}
+    const button = [
+      {buttonId: `${process.env.PREFIXO}afkmode 1`, buttonText: {displayText: "😴Silenciar"}, type: 1}
     ];
 
-
-  if (!groupAdmins.includes(msg.key.participant) && !await donos.findOne({userLid: sender})) {
-    await bot.sendNoAdmin(from);
-    return
-  }
-  
-
-  const seloTotag = {
-    key: {
-      remoteJid: from,
-      id: 'yuki123',
-      fromMe: false,
-      participant: msg.key.participant},
-      message: {
-        extendedTextMessage: {text: `⤷ ❄️ Mᴀʀᴄᴀᴄ̧ᴀ̃ᴏ ᴅᴏ ᴀᴅᴍɪɴ: ${msg.pushName}`}
-        
-      }
+    if (!allowed) {
+      await bot.sendNoAdmin(from);
+      return;
     }
-  
-  
-  const quoted = msg.message.extendedTextMessage?.contextInfo?.quotedMessage
-  
-  const msg_quoted = quoted?.conversation || quoted?.extendedTextMessage?.text || quoted?.documentMessage?.caption || texto
-  
-  const foto = quoted?.imageMessage
-  
-  const video = quoted?.videoMessage
-  
-  const sticker = quoted?.stickerMessage
-  
-  const enquete = quoted?.pollCreationMessageV3
-  
-  
- const metadata = await sock.groupMetadata(from);
- 
- const grupo = await grupos.findOne({groupId: from});
- 
- const afkList = grupo?.afkList ?? [];
 
-const todos = metadata.participants.map(p => p.id).filter(p => {
-  return !afkList.includes(p);
-});
-  
-  if (foto) {
-    const imgDl = await downloadMediaMessage({message: {imageMessage: foto}}, 'buffer', {})
-    await sock.sendMessage(from, { image: imgDl, caption: foto.caption, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag })
-    return
-  }
-  
-  if (video) {
-  const videoDl = await downloadMediaMessage({message: {videoMessage: video}}, 'buffer', {})
-  
-  await sock.sendMessage(from, { video: videoDl, caption: video.caption, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag })
-  return
-  }
-  
-  if (sticker) {
-    const stickerDl = await downloadMediaMessage({message: {stickerMessage: sticker}}, 'buffer', {})
-    
-    await sock.sendMessage(from, { sticker: stickerDl, mentions: todos}, { quoted: seloTotag })
-    return
-  }
-  if (msg_quoted) {
-    
-    await sock.sendMessage(from, { text: msg_quoted, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag})
-    return
-  }
-  
-  if (!msg_quoted) {
-    await sock.sendMessage(from, { text: texto, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag })
-    return
-  }
+    const seloTotag = {
+      key: {
+        remoteJid: from,
+        id: "yuki123",
+        fromMe: false,
+        participant: msg.key.participant
+      },
+      message: {
+        extendedTextMessage: {text: `⤷ ❄️ Marcação do admin: ${msg.pushName}`}
+      }
+    };
 
+    const quoted = msg.message.extendedTextMessage?.contextInfo?.quotedMessage;
+    const msg_quoted = quoted?.conversation || quoted?.extendedTextMessage?.text || quoted?.documentMessage?.caption || texto;
+    const foto = quoted?.imageMessage;
+    const video = quoted?.videoMessage;
+    const sticker = quoted?.stickerMessage;
 
+    const grupo = await ensureGroup(from, metadata);
+    const afkList = grupo?.afkList ?? [];
+    const todos = metadata.participants.map(p => p.id).filter(p => !afkList.includes(p));
 
-  else {
-    await sock.sendMessage(from, {text: "Responda uma mensagem ou digite algo!"}, {quoted: msg})
-    return
+    if (foto) {
+      const imgDl = await downloadMediaMessage({message: {imageMessage: foto}}, "buffer", {});
+      await sock.sendMessage(from, { image: imgDl, caption: foto.caption, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag });
+      return;
+    }
+
+    if (video) {
+      const videoDl = await downloadMediaMessage({message: {videoMessage: video}}, "buffer", {});
+      await sock.sendMessage(from, { video: videoDl, caption: video.caption, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag });
+      return;
+    }
+
+    if (sticker) {
+      const stickerDl = await downloadMediaMessage({message: {stickerMessage: sticker}}, "buffer", {});
+      await sock.sendMessage(from, { sticker: stickerDl, mentions: todos}, { quoted: seloTotag });
+      return;
+    }
+
+    if (msg_quoted) {
+      await sock.sendMessage(from, { text: msg_quoted, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag});
+      return;
+    }
+
+    if (!msg_quoted) {
+      await sock.sendMessage(from, { text: texto, mentions: todos, footer: "• Caso não queira ser marcado use: */afkmode 1*", buttons: button}, { quoted: seloTotag });
+      return;
+    }
+
+    await sock.sendMessage(from, {text: "Responda uma mensagem ou digite algo!"}, {quoted: msg});
   }
-  
-  
-  
-}
-
-}
+};

--- a/src/commands/admin/unmute.js
+++ b/src/commands/admin/unmute.js
@@ -1,54 +1,39 @@
 const { mutados } = require("../../database/models/mute");
-const { donos } = require("../../database/models/donos");
-const { numberBot } = require("../../config");
-
+const { getGroupPermission, invalidateMute } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "unmute",
-   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-     
-     async function reply(texto) {
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    async function reply(texto) {
       await sock.sendMessage(from, {text: texto}, {quoted: msg});
     }
-    
+
     try {
-      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-      
-      const metadata = await sock.groupMetadata(from);
-      
-      const admins = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const donoSender = await donos.findOne({userLid: sender});
-      
-      
-      if(!admins.includes(sender) && !donoSender) {
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+      const { allowed } = await getGroupPermission(sock, from, sender);
+
+      if(!allowed) {
         await reply("Você n é admin, zé bct");
-        return
+        return;
       }
-      
+
       if(!mention) {
         await reply("Mencione quem deseja desmutar.");
-        return
+        return;
       }
-      
-      const mutadoatual = await mutados.findOne({userLid: mention, grupo: from});
-      
-      if(!mutadoatual) {
+
+      const result = await mutados.deleteOne({userLid: mention, grupo: from});
+
+      if(!result.deletedCount) {
         await reply("Esse usuário não está mutado.");
-        return
+        return;
       }
-      
-      await mutados.deleteOne({userLid: mention, grupo: from});
-      
+
+      invalidateMute(mention, from);
       await reply("Usuário desmutado com sucesso!");
-    }
-    catch(err) {
+    } catch(err) {
       await reply(erros_prontos);
-      console.error(err)
+      console.error(err);
     }
-    
-    
-   }
-}
+  }
+};

--- a/src/commands/api/play.js
+++ b/src/commands/api/play.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
-const { users } = require("../../database/models/users");
 const { normalizeUserLid } = require("../../utils/normalizeUserLid");
+const { updateUserAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "play",
@@ -57,7 +57,7 @@ module.exports = {
     
     await sock.sendPresenceUpdate("paused", from);
     
-    await users.updateOne({userLid: normalizeUserLid(sender)}, {$inc: {donwloads: 1}});
+    await updateUserAndCache(normalizeUserLid(sender), {$inc: {donwloads: 1}});
     
     
   }

--- a/src/commands/donos/addGroup.js
+++ b/src/commands/donos/addGroup.js
@@ -1,54 +1,38 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { ensureGroupFromSocket, isOwnerCached } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "addgroup",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      //https://chat.whatsapp.com/EFySUUAtKCOBkYhkb7ytJY?mode=wwt
-      
-      
-      if(!await donos.findOne({userLid: sender})) {
+      if(!(await isOwnerCached(sender))) {
         await sock.sendMessage(from, {text: "Comando exclusivo para SubDonos."}, {quoted: msg});
-        return
+        return;
       }
-      
+
       const groupLink = args[0];
-      
+
       if(!groupLink) {
         await sock.sendMessage(from, {text: "Envia um link zé bct"}, {quoted: msg});
-        return
+        return;
       }
-      
+
       await sock.sendMessage(from, {text: "entrando no grupo..."}, {quoted: msg});
-      
+
       const groupId = groupLink.split("https://chat.whatsapp.com/")[1].split("?")[0].trim();
-      
       const acceptInvite = await sock.groupAcceptInvite(groupId);
-      
-      await grupos.create({groupId: acceptInvite});
-      
+
+      await ensureGroupFromSocket(sock, acceptInvite);
       await sock.sendMessage(acceptInvite, {text: `Olá! me chamo Yuki e meu prefixo neste grupo é */* caso queira mudar use */prefixo <prefix>*`}, {quoted: msg});
-      
-    }
-    catch(err) {
-      
-      const ifErro = String(err)
-      
+    } catch(err) {
+      const ifErro = String(err);
+
       if(ifErro.includes("not-authorized")) {
         await sock.sendMessage(from, {text: "Entrada ao grupo não autorizada! Tente mais tarde."}, {quoted: msg});
-        return
+        return;
       }
-      
-      
+
       await sock.sendMessage(from, {text: erros_prontos});
-      console.error(err)
+      console.error(err);
     }
-    
-    
-    
-    
-    
   }
-  
-}
+};

--- a/src/commands/donos/addVip.js
+++ b/src/commands/donos/addVip.js
@@ -1,63 +1,41 @@
-const { users } = require("../../database/models/users");
-const { donos } = require("../../database/models/donos");
-
+const { ensureUser, isOwnerCached, updateUserAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "addvip",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      
-      
-      const donoSender = await donos.findOne({userLid: sender});
-      
-      if(!donoSender) {
+      if(!(await isOwnerCached(sender))) {
         await sock.sendMessage(from, {text: "Só donos podem usar essa merda!"}, {quoted: msg});
-        return
+        return;
       }
-      
+
       const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0]
-  || msg.message?.extendedTextMessage?.contextInfo?.participant
-      
+        || msg.message?.extendedTextMessage?.contextInfo?.participant;
+
       if(!mention) {
         await sock.sendMessage(from, {text: "Marca alguém miserável!"}, {quoted: msg});
-        return
+        return;
       }
-      
-      let userMention = await users.findOne({userLid: mention});
-      
-      if(!userMention) {
-        await users.create({userLid: mention, name: msg.pushName || "sem nome"});
-        
-        userMention = await users.findOne({userLid: mention});
-      }
-      
+
+      await ensureUser(mention, msg.pushName || "sem nome");
+
       const parametro = args[0]?.trim();
-      
       const diasVip = Number(parametro);
-      
+
       if(!diasVip || diasVip <= 0) {
         await sock.sendMessage(from, {text: "Digite um valor de dias válido!"}, {quoted: msg});
-        return
+        return;
       }
-      
+
       const msgEspera = await sock.sendMessage(from, {text: "Adicionando vip..."}, {quoted: msg});
-      
-      
-      const diaMs = 24 * 60 * 60 * 1000
-      
-      const vencimentoMs = diasVip * diaMs
-      
-      
-      await users.updateOne({userLid: mention}, {$set: {isVip: true, vencimentoVip: Date.now() + vencimentoMs}});
-      
+      const diaMs = 24 * 60 * 60 * 1000;
+      const vencimentoMs = diasVip * diaMs;
+
+      await updateUserAndCache(mention, {$set: {isVip: true, vencimentoVip: Date.now() + vencimentoMs}});
       await sock.sendMessage(from, {text: `${diasVip} dias de vip adicionado para @${mention.split("@")[0]}`, edit: msgEspera.key, mentions: [mention]});
-      
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/donos/addowner.js
+++ b/src/commands/donos/addowner.js
@@ -1,4 +1,5 @@
 const { donos } = require("../../database/models/donos");
+const { invalidateOwner } = require("../../utils/dbHelpers");
 const { isOwnerLid } = require("../../utils/owner");
 
 module.exports = {
@@ -19,12 +20,18 @@ module.exports = {
         return;
       }
 
-      if (await donos.findOne({ userLid: mention })) {
+      const owner = await donos.findOneAndUpdate(
+        { userLid: mention },
+        { $setOnInsert: { userLid: mention } },
+        { upsert: true, new: false }
+      );
+
+      if (owner) {
         await sock.sendMessage(from, { text: "Este usuário já é dono." }, { quoted: msg });
         return;
       }
 
-      await donos.create({ userLid: mention });
+      invalidateOwner(mention);
       await sock.sendMessage(from, { text: "Novo dono registrado com sucesso!" }, { quoted: msg });
     } catch (err) {
       await sock.sendMessage(from, { text: erros_prontos }, { quoted: msg });

--- a/src/commands/donos/aluguel.js
+++ b/src/commands/donos/aluguel.js
@@ -1,56 +1,38 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
-
+const { isOwnerCached, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "addaluguel",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
       const metadata = await sock.groupMetadata(from);
-      
-      
-      
-      
-      const donoSender = await donos.findOne({userLid: sender});
-      
-      if(!donoSender) {
+
+      if(!(await isOwnerCached(sender))) {
         await sock.sendMessage(from, {text: "Só donos podem usar essa merda!"}, {quoted: msg});
-        return
+        return;
       }
-      
+
       if(!from.endsWith("@g.us")) {
         await sock.sendMessage(from, {text: "Use em um grupo."}, {quoted: msg});
-        return
+        return;
       }
-      
+
       const parametro = args?.slice(0).join(" ").trim();
-      
       const diasAluguel = Number(parametro);
-      
+
       if(!diasAluguel || diasAluguel <=0) {
         await sock.sendMessage(from, {text: "Digite dias válidos!"}, {quoted: msg});
-        return
+        return;
       }
-      
+
       const msgEspera = await sock.sendMessage(from, {text: `Adicionando ${diasAluguel} dias, ao grupo...`}, {quoted: msg});
-      
-      
-      
-      
-      const diaMs = 24 * 60 * 60 * 1000
-      
-      const diasVencimento = diasAluguel * diaMs
-      
-      await grupos.updateOne({groupId: from}, {$set: {aluguel: diasVencimento + Date.now(), grupoName: metadata.subject}});
-      
+      const diaMs = 24 * 60 * 60 * 1000;
+      const diasVencimento = diasAluguel * diaMs;
+
+      await updateGroupAndCache(from, {$set: {aluguel: diasVencimento + Date.now(), grupoName: metadata.subject}}, {metadata});
       await sock.sendMessage(from, {text: 'Dias adicionados com sucesso! Use: "/grupoinfo", para ver mais informações.', edit: msgEspera.key});
-      
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/donos/annoucement.js
+++ b/src/commands/donos/annoucement.js
@@ -1,7 +1,7 @@
 const crypto = require("crypto");
 const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
 const { prefixo } = require("../../config");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 
 const pendingAnnouncements = new Map();
 
@@ -158,8 +158,7 @@ Pulados: ${result.skipped}${errorsText}`
 }
 
 async function assertOwner(sock, msg, from, sender) {
-  const donoSender = await donos.findOne({ userLid: sender });
-  if (donoSender) return true;
+  if (await isOwnerCached(sender)) return true;
 
   await sock.sendMessage(from, { text: "Só dono pode usar announcement, meu mano." }, { quoted: msg });
   return false;

--- a/src/commands/donos/archiveGroup.js
+++ b/src/commands/donos/archiveGroup.js
@@ -1,4 +1,4 @@
-const { donos } = require("../../database/models/donos");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 
 function chunk(arr, size) {
   const out = [];
@@ -14,9 +14,8 @@ module.exports = {
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
       const rawSender = sender
-      const dono = await donos.findOne({ userLid: rawSender });
 
-      if (!dono) {
+      if (!(await isOwnerCached(rawSender))) {
         await sock.sendMessage(from, { text: "Comando de dono." });
         return;
       }

--- a/src/commands/donos/cleartemp.js
+++ b/src/commands/donos/cleartemp.js
@@ -1,5 +1,5 @@
 const fs = require("fs").promises
-const { donos } = require("../../database/models/donos");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "cleartemp",
@@ -9,9 +9,7 @@ module.exports = {
       
       
       
-      const doninhos = await donos.findOne({userLid: sender})
-      
-      if(!doninhos) {
+      if(!(await isOwnerCached(sender))) {
         await sock.sendMessage(from, {text: "Comando exlusivo para donos!"}, {quoted: msg});
         return
       }

--- a/src/commands/donos/getfile.js
+++ b/src/commands/donos/getfile.js
@@ -1,56 +1,46 @@
 const fs = require("fs");
 const path = require("path");
-const { numberOwner } = require("../../config")
-const { donos } = require("../../database/models/donos.js");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "getfile",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-    const caminho = args[0]
-    const proibidos = [".env", ".json", ".sh"]
-    
-    const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-    
-    const donoSender = await donos.findOne({userLid: sender});
-    
-    if(!donoSender) {
-      await sock.sendMessage(from, {text: "Só o Sub-Donos podem usar esse comando."}, {quoted: msg});
-      return
-    }
-    
-    if(!caminho) {
-      await sock.sendMessage(from, {text: "digita o caminho pau no cu"}, {quoted: msg});
-      return
-    }
-    
-    if(!fs.existsSync(caminho)) {
-      await sock.sendMessage(from, {text: "Digita um caminho válido, zé bct"}, {quoted: msg});
-      return
-    }
-    
-    if(proibidos.some(p => caminho.endsWith(p))) {
-      await sock.sendMessage(from, {text: "Esses arquivo não mando nem fudendo, pau no cu!"}, {quoted: msg});
-      return
-    }
-    
-    if(mention) {
-      const esperaM = await bot.reply(from, "Enviando arquivo pro usuário...");
-      await sock.sendMessage(mention, {document: {url: caminho}, mimetype: "application/javascript", fileName: path.basename(caminho), caption: `O @${sender.split("@")[0]} Me pediu pra enviar esse arquivo pra você!`, mentions: [sender]});
-      
-      await bot.editReply(from, esperaM.key, "Arquivo enviado com sucesso!");
-      return
-    }
-    
-    await sock.sendMessage(from, {document: {url: caminho}, mimetype: "application/javascript", fileName: path.basename(caminho)}, {quoted: msg});
-    
-    }
-    catch(err) {
+      const caminho = args[0];
+      const proibidos = [".env", ".json", ".sh"];
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+
+      if(!(await isOwnerCached(sender))) {
+        await sock.sendMessage(from, {text: "Só o Sub-Donos podem usar esse comando."}, {quoted: msg});
+        return;
+      }
+
+      if(!caminho) {
+        await sock.sendMessage(from, {text: "digita o caminho pau no cu"}, {quoted: msg});
+        return;
+      }
+
+      if(!fs.existsSync(caminho)) {
+        await sock.sendMessage(from, {text: "Digita um caminho válido, zé bct"}, {quoted: msg});
+        return;
+      }
+
+      if(proibidos.some(p => caminho.endsWith(p))) {
+        await sock.sendMessage(from, {text: "Esses arquivo não mando nem fudendo, pau no cu!"}, {quoted: msg});
+        return;
+      }
+
+      if(mention) {
+        const esperaM = await bot.reply(from, "Enviando arquivo pro usuário...");
+        await sock.sendMessage(mention, {document: {url: caminho}, mimetype: "application/javascript", fileName: path.basename(caminho), caption: `O @${sender.split("@")[0]} Me pediu pra enviar esse arquivo pra você!`, mentions: [sender]});
+        await bot.editReply(from, esperaM.key, "Arquivo enviado com sucesso!");
+        return;
+      }
+
+      await sock.sendMessage(from, {document: {url: caminho}, mimetype: "application/javascript", fileName: path.basename(caminho)}, {quoted: msg});
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
-    
-    
   }
-}
+};

--- a/src/commands/donos/grupos.js
+++ b/src/commands/donos/grupos.js
@@ -1,5 +1,5 @@
 const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "listargrupos",
@@ -7,16 +7,14 @@ module.exports = {
     try {
       
       
-      const donoSender = await donos.findOne({userLid: sender});
-      
-      if(!donoSender) {
+      if(!(await isOwnerCached(sender))) {
         await sock.sendMessage(from, {text: "Só donos podem usar essa merda!"}, {quoted: msg});
         return
       }
       
       const esperaMsg = await sock.sendMessage(from, {text: "Buscando grupos..."}, {quoted: msg});
       
-      const gruposArray = await grupos.find();
+      const gruposArray = await grupos.find().lean();
       
       
       

--- a/src/commands/donos/reset.js
+++ b/src/commands/donos/reset.js
@@ -1,4 +1,4 @@
-const { donos } = require("../../database/models/donos");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 
 
 module.exports = {
@@ -23,9 +23,7 @@ module.exports = {
       
       
       
-      const donoSender = await donos.findOne({userLid: sender});
-      
-      if(!donoSender) {
+      if(!(await isOwnerCached(sender))) {
         await sock.sendMessage(from, {text: "Tu não é dono, viadinho!"}, {quoted: msg});
         return;
       }

--- a/src/commands/donos/seradmin.js
+++ b/src/commands/donos/seradmin.js
@@ -1,13 +1,11 @@
-const { donos } = require("../../database/models/donos");
+const { isOwnerCached } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "seradmin",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
       
-      const dono = await donos.findOne({userLid: sender});
-      
-      if(!dono) {
+      if(!(await isOwnerCached(sender))) {
         await sock.sendMessage(from, {text: "Você é dono? Seu filho da puta"}, {quoted: msg});
         return
       }

--- a/src/commands/economia/casar.js
+++ b/src/commands/economia/casar.js
@@ -1,87 +1,69 @@
 const { clientRedis } = require("../../lib/redis.js");
-const { users } = require("../../database/models/users");
 const { numberBot } = require("../../config");
-
+const { ensureUser } = require("../../utils/dbHelpers");
 
 module.exports = {
- name: "namorar",
- async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-   try {
-     
-     const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-     
-     
-     
-     if(!mention) {
-       await sock.sendMessage(from, {text: "Menciona alguém, seu jumento(a) inseguro!"}, {quoted: msg});
-       return
-     }
-     
-     if(mention.includes(numberBot)) {
-       await sock.sendMessage(from, {text: "Eii! Eu sou apenas uma bot!"}, {quoted: msg});
-       return
-     }
-     
-     let userSender = await users.findOne({userLid: sender});
-     
-     let userMention = await users.findOne({userLid: mention});
-     
-     if(!userSender) {
-       await users.create({userLid: sender});
-       
-       userSender = await users.findOne({userLid: sender});
-     }
-     
-     if(!userMention) {
-       await users.create({userLid: mention});
-       
-       userMention = await users.findOne({userLid: mention});
-     }
-     
-     if(userSender.casal?.parceiro) {
-       await sock.sendMessage(from, {text: `Hum... Estou sentindo um pouco de traição da sua parte viu...`}, {quoted: msg});
-       return
-     }
-     
-     if(userMention.casal?.parceiro) {
-       await sock.sendMessage(from, {text: "Ei!!! Essa pessoa já está em um relacionamento. Sinto informar..."}, {quoted: msg});
-       return
-     }
-     
-     const pedidoExisteMention = await clientRedis.exists(`namoro:${mention}`);
-     
-     const pedidoExisteSender = await clientRedis.exists(`namoro:${sender}`);
-     
-     if(pedidoExisteMention) {
-       await sock.sendMessage(from, {text: "Este usuário já possui um pedido pendente!"}, {quoted: msg});
-       return
-     }
-     
-     if(pedidoExisteSender) {
-       await sock.sendMessage(from, {text: "Você já possui um pedido pendente!"}, {quoted: msg});
-       return
-     }
-     
-     //await namoros.create({alvo: mention, pedidor: sender});
-     await clientRedis.hSet(`namoro:${mention}`, {
-       alvo: mention,
-       autor: sender
-     });
-     
-     await clientRedis.expire(`namoro:${mention}`, 10 * 60);
-     
-     const buttons = [
-       {buttonId: "aceitar", buttonText: {displayText: "𝐀𝐜𝐞𝐢𝐭𝐨😍💖"}, type: 1},
-       {buttonId: "recusar", buttonText: {displayText: "𝐑𝐞𝐜𝐮𝐬𝐚𝐫😒"}}
-       ];
-     
-     await sock.sendMessage(from, {text: `O(a) @${mention.split("@")[0]} acaba de ser pedida em namoro por @${sender.split("@")[0]}💕\nResponda essa mensagem com: Aceitar ou Recusar`, buttons: buttons, mentions: [mention, sender]}, {quoted: msg});
-    
-   }
-   catch(err) {
-     await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
-     console.error(err);
-   }
-   
- }
-}
+  name: "namorar",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
+
+      if(!mention) {
+        await sock.sendMessage(from, {text: "Menciona alguém, seu jumento(a) inseguro!"}, {quoted: msg});
+        return;
+      }
+
+      if(mention.includes(numberBot)) {
+        await sock.sendMessage(from, {text: "Eii! Eu sou apenas uma bot!"}, {quoted: msg});
+        return;
+      }
+
+      const [userSender, userMention] = await Promise.all([
+        ensureUser(sender, msg.pushName || "Sem nome"),
+        ensureUser(mention, "Sem nome")
+      ]);
+
+      if(userSender.casal?.parceiro) {
+        await sock.sendMessage(from, {text: `Hum... Estou sentindo um pouco de traição da sua parte viu...`}, {quoted: msg});
+        return;
+      }
+
+      if(userMention.casal?.parceiro) {
+        await sock.sendMessage(from, {text: "Ei!!! Essa pessoa já está em um relacionamento. Sinto informar..."}, {quoted: msg});
+        return;
+      }
+
+      const [pedidoExisteMention, pedidoExisteSender] = await Promise.all([
+        clientRedis.exists(`namoro:${mention}`),
+        clientRedis.exists(`namoro:${sender}`)
+      ]);
+
+      if(pedidoExisteMention) {
+        await sock.sendMessage(from, {text: "Este usuário já possui um pedido pendente!"}, {quoted: msg});
+        return;
+      }
+
+      if(pedidoExisteSender) {
+        await sock.sendMessage(from, {text: "Você já possui um pedido pendente!"}, {quoted: msg});
+        return;
+      }
+
+      await clientRedis.hSet(`namoro:${mention}`, {
+        alvo: mention,
+        autor: sender
+      });
+
+      await clientRedis.expire(`namoro:${mention}`, 10 * 60);
+
+      const buttons = [
+        {buttonId: "aceitar", buttonText: {displayText: "Aceitar😍💖"}, type: 1},
+        {buttonId: "recusar", buttonText: {displayText: "Recusar😒"}}
+      ];
+
+      await sock.sendMessage(from, {text: `O(a) @${mention.split("@")[0]} acaba de ser pedida em namoro por @${sender.split("@")[0]}💕\nResponda essa mensagem com: Aceitar ou Recusar`, buttons: buttons, mentions: [mention, sender]}, {quoted: msg});
+    } catch(err) {
+      await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
+      console.error(err);
+    }
+  }
+};

--- a/src/commands/economia/coinFlipBet.js
+++ b/src/commands/economia/coinFlipBet.js
@@ -1,5 +1,5 @@
-const { users } = require("../../database/models/users");
 const { clientRedis } = require("../../lib/redis.js");
+const { ensureUser } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "coinflipbet",
@@ -11,73 +11,59 @@ module.exports = {
 Responda alguém ou mencione usando o comando junto com o valor desejado.
 > Exemplo: coinflip 100 @yuki
 
-Simples pra até pra um bebê`)
+Simples pra até pra um bebê`);
       }
-      
-      
-      
+
       const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0]
-  || msg.message?.extendedTextMessage?.contextInfo?.participant
-      
-      
-      
-      const userSender = await users.findOne({userLid: sender});
-      
-      const userMention = await users.findOne({userLid: mention});
-      
+        || msg.message?.extendedTextMessage?.contextInfo?.participant;
+
       if(!mention) {
         await sendHelp();
-        return
+        return;
       }
-      
-      const parametroMoney = Number(args[0].trim());
-      
-      
-      
-      if(!parametroMoney) {
+
+      const parametroMoney = Number(args[0]?.trim());
+
+      if(!parametroMoney || parametroMoney <= 0) {
         await sendHelp();
-        return
+        return;
       }
-      
-      if(!userMention && parametroMoney > userMention.dinheiro) {
-        await bot.reply(from, "Este usuário não possui essa quantidade de moedas!")
-        return
-      }
-      
+
+      const [userSender, userMention] = await Promise.all([
+        ensureUser(sender, msg.pushName || "Sem nome"),
+        ensureUser(mention, "Sem nome")
+      ]);
+
       if(parametroMoney > userSender.dinheiro) {
         await bot.reply(from, "Você não possui esse valor!");
-        return
+        return;
       }
-      
+
       if(parametroMoney > userMention.dinheiro) {
         await sock.sendMessage(from, {text: `@${mention.split("@")[0]} não possui este valor!`, mentions: [mention]}, {quoted: msg});
-        return
+        return;
       }
-      
-      const desafiopassado = await clientRedis.exists(`aposta:${mention}`)
-      
+
+      const desafiopassado = await clientRedis.exists(`aposta:${mention}`);
+
       if(desafiopassado) {
         await bot.reply(from, "Você possui uma aposta pendente.");
-        return
+        return;
       }
-      
-      //await desafios.create({user: sender, alvo: mention, valor: parametroMoney});
+
       await clientRedis.hSet(`aposta:${mention}`, {
         autor: sender,
         alvo: mention,
         valor: parametroMoney,
-        resolvida: 'false'
+        resolvida: "false"
       });
-      
+
       await clientRedis.expire(`aposta:${mention}`, 60);
-      
+
       await sock.sendMessage(from, {text: `@${mention.split("@")[0]}... Você acaba de ser desafiado para um cara ou coroa por @${sender.split("@")[0]}. Responda com um: *aceitar* ou *recusar*`, mentions: [mention, sender]}, {quoted: msg});
-      
-    }
-    catch(err) {
+    } catch(err) {
       await bot.reply(from, erros_prontos);
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/economia/comprarWaifu.js
+++ b/src/commands/economia/comprarWaifu.js
@@ -1,72 +1,76 @@
 const waifus = require("../../database/waifus/waifus.json");
 const preco = require("../../database/waifus/raridadePreço.json");
-const { users } = require("../../database/models/users.js");
-const path = require("path");
 const { comprarWaifu } = require("../../utils/events.js");
-
+const { ensureUser, updateUserAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "comprarwaifu",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
       async function sendHelp() {
         await bot.reply(from, `Como comprar waifus:
 
 ⤷  ao usar */comprarwaifu* pegue o *id* da waifu que deseja comprar, pode fazer isso usando */loja*.
 > Exemplo: /comprar waifu 20
-Caso tenha o valor que custa a waifu ela será adicionada ao seu inventário.`)
+Caso tenha o valor que custa a waifu ela será adicionada ao seu inventário.`);
       }
-      
-      
+
       const parametro = Number(args[0]);
-      
+
       if(!parametro) {
-        sendHelp();
-        return
+        await sendHelp();
+        return;
       }
-      
+
       const waifuFind = waifus.find(item => item.id === parametro);
-      
+
       if(!waifuFind) {
         await bot.reply(from, "Não encontrei nenhuma waifu com esse id. Use /loja para ver cada id.");
-        return
+        return;
       }
-      
+
       const waifuEscolhida = {
-          nome: waifuFind.nome,
-          id: waifuFind.id,
-          raridade: waifuFind.raridade,
-          img: waifuFind.image,
-          preco: preco[waifuFind.raridade]
-        }
-      
-      
-      
-      const userSender = await users.findOne({userLid: sender});
-      
+        nome: waifuFind.nome,
+        id: waifuFind.id,
+        raridade: waifuFind.raridade,
+        img: waifuFind.image,
+        preco: preco[waifuFind.raridade]
+      };
+
+      const userSender = await ensureUser(sender, msg.pushName || "Sem nome");
+
       if(userSender.dinheiro < waifuEscolhida.preco) {
         await bot.reply(from, `${userSender.name}... No momento você não possui o valor suficiente para comprar a ${waifuEscolhida.nome}...`);
-        return
+        return;
       }
-      else {
-        await users.updateOne({ userLid: sender }, { $push: {waifus: { nome: waifuEscolhida.nome,
-        image: waifuEscolhida.img,
-        id: waifuEscolhida.id,
-        raridade: waifuEscolhida.raridade,
-        preco: waifuEscolhida.preco
-        }
-        }, $inc: {dinheiro: -waifuEscolhida.preco}});
-        
-        await bot.reply(from, `${waifuEscolhida.nome}, comprada com sucesso!`);
-        comprarWaifu({ctx: msg, waifu: waifuEscolhida})
-        
+
+      const result = await updateUserAndCache(
+        sender,
+        {
+          $push: {
+            waifus: {
+              nome: waifuEscolhida.nome,
+              image: waifuEscolhida.img,
+              id: waifuEscolhida.id,
+              raridade: waifuEscolhida.raridade,
+              preco: waifuEscolhida.preco
+            }
+          },
+          $inc: { dinheiro: -waifuEscolhida.preco }
+        },
+        {filter: {dinheiro: {$gte: waifuEscolhida.preco}}}
+      );
+
+      if(!result) {
+        await bot.reply(from, `${userSender.name}... No momento você não possui o valor suficiente para comprar a ${waifuEscolhida.nome}...`);
+        return;
       }
-    }
-    catch(err) {
+
+      await bot.reply(from, `${waifuEscolhida.nome}, comprada com sucesso!`);
+      comprarWaifu({ctx: msg, waifu: waifuEscolhida});
+    } catch(err) {
       await bot.reply(from, erros_prontos);
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/economia/description.js
+++ b/src/commands/economia/description.js
@@ -1,38 +1,25 @@
-const { users } = require("../../database/models/users");
+const { ensureUser, updateUserAndCache } = require("../../utils/dbHelpers");
 const { normalizeUserLid } = require("../../utils/normalizeUserLid");
-
 
 module.exports = {
   name: "mudarbio",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      
-      
       const normalizedSender = normalizeUserLid(sender);
-
-      if(!await users.findOne({userLid: normalizedSender})) {
-        await users.create({userLid: normalizedSender, name: msg.pushName || "Sem nome"});
-      }
-      
       const bioText = args?.join(" ")?.trim();
-      
+
       if(!bioText) {
         await sock.sendMessage(from, {text: `Coloque a bio desejada. Exemplo: "/mudarbio Eu amo o Speed"`}, {quoted: msg});
-        return
+        return;
       }
-      
+
+      await ensureUser(normalizedSender, msg.pushName || "Sem nome");
       await sock.sendMessage(from, {text: "Mudando bio..."}, {quoted: msg});
-      
-      await users.updateOne({userLid: normalizedSender}, {$set: {bio: bioText}});
-      
+      await updateUserAndCache(normalizedSender, {$set: {bio: bioText}});
       await sock.sendMessage(from, {text: `Bio mudada para: "${bioText}", use /perfil para ver alterações.`}, {quoted: msg});
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
-    
   }
-}
+};

--- a/src/commands/economia/diario.js
+++ b/src/commands/economia/diario.js
@@ -1,37 +1,26 @@
-const { users } = require("../../database/models/users");
+const { ensureUser, updateUserAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "diario",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      
-      
-      const userSender = await users.findOne({userLid: sender});
-      
+      const userSender = await ensureUser(sender, msg.pushName || "Sem nome");
       const agr = new Date().toLocaleDateString("pt-BR");
-      
-      const ultimoDaily = userSender?.daily ?   new Date(userSender.daily).toLocaleDateString("pt-BR") : null;
-      
+      const ultimoDaily = userSender?.daily ? new Date(userSender.daily).toLocaleDateString("pt-BR") : null;
+
       if(ultimoDaily && agr === ultimoDaily) {
         await bot.reply(from, "Ei seu espertinho! Você já resgatou seu diário de hoje, volte amanhã");
-        return
+        return;
       }
-      
+
       await bot.reply(from, espera_pronta);
-      
+
       const dinheiro = Math.floor(Math.random() * 1000);
-      
-      
-      await users.updateOne({userLid: sender}, {$set: {daily: new Date()}, $inc: {dinheiro: dinheiro}});
-      
+      await updateUserAndCache(sender, {$set: {daily: new Date()}, $inc: {dinheiro: dinheiro}});
       await bot.reply(from, `${msg.pushName || "Sem nome"}, parabéns você ganhou ${dinheiro} moedas`);
-      
-    }
-    catch(err) {
+    } catch(err) {
       await bot.reply(from, erros_prontos);
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/economia/perfil.js
+++ b/src/commands/economia/perfil.js
@@ -1,51 +1,31 @@
-const { users } = require("../../database/models/users");
 const axios = require("axios");
 const path = require("path");
+const { ensureUser } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "perfil",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
       await sock.sendMessage(from, {text: espera_pronta}, {quoted: msg});
-      
+
       const buttons = [
-        {buttonId: `${process.env.PREFIXO}xp`, buttonText: {displayText: "𝐕𝐄𝐑 𝐗𝐏💖"}, type: 1},
-        {buttonId: `${process.env.PREFIXO}waifus`, buttonText: {displayText: "𝐯𝐞𝐫 𝐰𝐚𝐢𝐟𝐮𝐬"}, type: 1}
-        ];
-      
-      const Isuser = await users.findOne({userLid: sender});
-      
-      let status;
-      
-      try {
-      status = await axios.get(process.env.URL_BACKEND + `/music?user=${sender}`);
-      }
-      catch(err) {
+        {buttonId: `${process.env.PREFIXO}xp`, buttonText: {displayText: "VER XP💖"}, type: 1},
+        {buttonId: `${process.env.PREFIXO}waifus`, buttonText: {displayText: "ver waifus"}, type: 1}
+      ];
+
+      const statusPromise = axios.get(process.env.URL_BACKEND + `/music?user=${sender}`).catch((err) => {
         console.log(err);
-        status = undefined;
-      }
+        return undefined;
+      });
+
+      const profilePromise = sock.profilePictureUrl(sender, "image").catch(() => null);
+      const userSender = await ensureUser(sender, msg.pushName || "Sem nome");
+      const [status, senderProfile] = await Promise.all([statusPromise, profilePromise]);
       const dataStatus = status?.data;
-      
-      if(!Isuser) {
-        await users.create({userLid: sender, name: msg.pushName || "Sem nome"});
-      }
-      
-      const userSender = await users.findOne({userLid: sender});
-      
-      
-      let senderProfile;
-      
-      try {
-        senderProfile = await sock.profilePictureUrl(sender, "image");
-      } catch(e) {
-        senderProfile = null;
-      }
-      
+
       const vencimentoMs = userSender?.vencimentoVip - Date.now();
-      
-      const vencimentoDias = Math.max(0, Math.ceil(vencimentoMs / (24 * 60 * 60 * 1000)))
-      
+      const vencimentoDias = Math.max(0, Math.ceil(vencimentoMs / (24 * 60 * 60 * 1000)));
+
       const infos = `*User:* @${userSender.userLid.split("@")[0]}
 *Criado em:* ${userSender.registro.toLocaleDateString("pt-BR")}
 *Bio:* ${userSender.bio}
@@ -62,26 +42,21 @@ module.exports = {
 *Comandos usados:* ${userSender.cmdCount}
 *Downloads:* ${userSender.donwloads}
 *Figurinhas:* ${userSender.figurinhas}
-`
+`;
 
-    
-    const assetsPast = '../../assets/images'
-      
-    
-
+      const assetsPast = "../../assets/images";
       const icons = [`${assetsPast}/yuki.jpg`, `${assetsPast}/yuki2.jpg`, `${assetsPast}/yuki3.jpg`, `${assetsPast}/yuki4.jpg`, `${assetsPast}/yuki5.jpg`];
-      
       const imgsRandom = icons[Math.floor(Math.random() * icons.length)];
-    
-    
-      await sock.sendMessage(from, {image: {url: senderProfile ? senderProfile : path.join(__dirname ,imgsRandom)}, caption: infos, mentions: [sender, ...(userSender?.casal?.parceiro ? [userSender.casal.parceiro] : [])], buttons: buttons}, {quoted: msg});
-      
-      
-      
-    }
-    catch(err) {
+
+      await sock.sendMessage(from, {
+        image: {url: senderProfile ? senderProfile : path.join(__dirname ,imgsRandom)},
+        caption: infos,
+        mentions: [sender, ...(userSender?.casal?.parceiro ? [userSender.casal.parceiro] : [])],
+        buttons: buttons
+      }, {quoted: msg});
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
-      console.error(err)
+      console.error(err);
     }
   }
-}
+};

--- a/src/commands/economia/rankCmd.js
+++ b/src/commands/economia/rankCmd.js
@@ -7,7 +7,7 @@ module.exports = {
     try {
       const msgEspera = await sock.sendMessage(from, { text: "Buscando usuários ativos..." }, { quoted: msg });
 
-      const globalUsers = await users.find().sort({ cmdCount: -1 }).limit(10);
+      const globalUsers = await users.find().sort({ cmdCount: -1 }).limit(10).lean();
 
       const rankMap = globalUsers
         .filter((p) => !isOwnerLid(p.userLid))

--- a/src/commands/economia/rankMoeda.js
+++ b/src/commands/economia/rankMoeda.js
@@ -7,10 +7,10 @@ module.exports = {
     try {
       const msgEspera = await bot.reply(from, "Buscando rank...");
 
-      const dono = await donos.find();
+      const dono = await donos.find().lean();
       const donosIds = dono.map((i) => i.userLid);
 
-      const usersRank = await users.find({ userLid: { $nin: donosIds } }).sort({ dinheiro: -1 }).limit(10);
+      const usersRank = await users.find({ userLid: { $nin: donosIds } }).sort({ dinheiro: -1 }).limit(10).lean();
 
       const rank = usersRank.map((item, indice) => {
         return `${indice + 1}° @${item.userLid.split("@")[0]}\n⤷ *Moedas:* ${item.dinheiro}\n⤷ *Quantidade de waifu:* ${item.waifus.length}`;

--- a/src/commands/economia/rankxp.js
+++ b/src/commands/economia/rankxp.js
@@ -8,7 +8,7 @@ module.exports = {
    async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
 
-        const usersAll = await users.find().sort({level: -1}).limit(10);
+        const usersAll = await users.find().sort({level: -1}).limit(10).lean();
 
         const rank = usersAll.map((user, index) => {
             return `${index + 1}º @${user.userLid.split("@")[0]}

--- a/src/commands/economia/saldo.js
+++ b/src/commands/economia/saldo.js
@@ -1,4 +1,4 @@
-const { users } = require("../../database/models/users");
+const { ensureUser } = require("../../utils/dbHelpers");
 const { normalizeUserLid } = require("../../utils/normalizeUserLid");
 
 module.exports = {
@@ -8,23 +8,12 @@ module.exports = {
       await sock.sendMessage(from, { text: espera_pronta }, { quoted: msg });
 
       const senderLid = normalizeUserLid(sender);
-
-      let userFind = await users.findOne({ userLid: senderLid });
-
-      if (!userFind) {
-        userFind = await users.create({
-          userLid: senderLid,
-          name: msg.pushName || "Sem nome",
-          dinheiro: 0
-        });
-      }
-
+      const userFind = await ensureUser(senderLid, msg.pushName || "Sem nome");
       const saldo = Number(userFind.dinheiro || 0);
 
       await sock.sendMessage(from, {
         text: `${msg.pushName || "sem nome"}, você tem ${saldo} de saldo.`
       }, { quoted: msg });
-
     } catch (err) {
       console.error(err);
       await sock.sendMessage(from, { text: erros_prontos }, { quoted: msg });

--- a/src/commands/economia/terminar.js
+++ b/src/commands/economia/terminar.js
@@ -1,32 +1,25 @@
-const { users } = require("../../database/models/users");
-
+const { ensureUser, updateUserAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "terminar",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      
-      
-      const userDiv = await users.findOne({userLid: sender});
-      
+      const userDiv = await ensureUser(sender, msg.pushName || "Sem nome");
+
       if(!userDiv.casal.parceiro) {
         await sock.sendMessage(from, {text: "Você nem tem namorado(a) bro💔💔"}, {quoted: msg});
-        return
+        return;
       }
-      
-      //deleta do user
-      await users.updateOne({userLid: sender}, {$set: {"casal.parceiro": null, "casal.pedido": null}});
-      //deleta da namorada
-      await users.updateOne({userLid: userDiv.casal.parceiro}, {$set: {"casal.parceiro": null, "casal.pedido": null}});
-      
+
+      await Promise.all([
+        updateUserAndCache(sender, {$set: {"casal.parceiro": null, "casal.pedido": null}}),
+        updateUserAndCache(userDiv.casal.parceiro, {$set: {"casal.parceiro": null, "casal.pedido": null}})
+      ]);
+
       await sock.sendMessage(from, {text: `NÃO!! 😭😭 @${sender.split("@")[0]} terminou com @${userDiv?.casal?.parceiro.split("@")[0]}💔💔`, mentions: [sender, userDiv.casal.parceiro]}, {quoted: msg});
-      
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/economia/transferir.js
+++ b/src/commands/economia/transferir.js
@@ -1,72 +1,59 @@
-const { users } = require("../../database/models/users.js");
+const { ensureUser, invalidateUser, updateUserAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "transferir",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-    
     async function sendHelp() {
-        await bot.reply(from, `*Como usar comandos de economia*
+      await bot.reply(from, `*Como usar comandos de economia*
 
 Responda alguém ou mencione usando o comando junto com o valor desejado.
 > Exemplo: /transferir 100 @yuki
 
-Simples pra até pra um bebê`)
-      }
-    
+Simples pra até pra um bebê`);
+    }
+
     try {
-      
-      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant
-      
-      
-      
+      const mention = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0] || msg.message?.extendedTextMessage?.contextInfo?.participant;
       const parametro = Number(args[0]);
-      
-      if(!mention) {
+
+      if(!mention || !parametro) {
         await sendHelp();
-        return
+        return;
       }
-      
-      let userMention = await users.findOne({userLid: mention});
-      
-      const userSender = await users.findOne({userLid: sender});
-      
-      if(!userMention) {
-        await users.create({userLid: mention, name: "sem nome"});
-        
-        userMention = await users.findOne({userLid: mention});
-      }
-      
-      
-      if(!parametro) {
-        await sendHelp();
-        return
-      }
-      
+
       if(parametro <=0) {
         await bot.reply(from, "Envie um valor maior que zero.");
-        return
+        return;
       }
-      
-    if(parametro > userSender.dinheiro) {
-      await bot.reply(from, "Você não possui esse valor.");
-      return
-    }
-    
-    await bot.reply(from, `Transferindo moedas...`);
-    
-    //remove de quem transferiu
-    await users.updateOne({userLid: sender}, {$inc: {dinheiro: -parametro}}, {upsert: true});
-    
-    //incrementa pro alvo
-    await users.updateOne({userLid: mention}, {$inc: {dinheiro: parametro}});
-      
-    await sock.sendMessage(from, {text: `O @${sender.split("@")[0]} enviou ${parametro} moedas pro @${mention.split("@")[0]}!`, mentions: [sender, mention]}, {quoted: msg});
-      
-    }
-    catch(err) {
+
+      await Promise.all([
+        ensureUser(sender, msg.pushName || "Sem nome"),
+        ensureUser(mention, "sem nome")
+      ]);
+
+      const debit = await updateUserAndCache(
+        sender,
+        {$inc: {dinheiro: -parametro}},
+        {filter: {dinheiro: {$gte: parametro}}}
+      );
+
+      if(!debit) {
+        invalidateUser(sender);
+        await bot.reply(from, "Você não possui esse valor.");
+        return;
+      }
+
+      try {
+        await updateUserAndCache(mention, {$inc: {dinheiro: parametro}});
+      } catch (err) {
+        await updateUserAndCache(sender, {$inc: {dinheiro: parametro}});
+        throw err;
+      }
+
+      await sock.sendMessage(from, {text: `O @${sender.split("@")[0]} enviou ${parametro} moedas pro @${mention.split("@")[0]}!`, mentions: [sender, mention]}, {quoted: msg});
+    } catch(err) {
       await bot.reply(from, erros_prontos);
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/economia/waifus.js
+++ b/src/commands/economia/waifus.js
@@ -1,28 +1,22 @@
-const { users } = require("../../database/models/users.js");
-
+const { ensureUser } = require("../../utils/dbHelpers");
 
 module.exports = {
-    name: "waifus",
-    async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-        try {
+  name: "waifus",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      const user = await ensureUser(sender, msg.pushName || "Sem nome");
 
-            const user = await users.findOne({userLid: sender});
-
-            const waifusInv = user.waifus.map((item, index) => {
-                return `${index + 1}º ${item.nome}
+      const waifusInv = user.waifus.map((item, index) => {
+        return `${index + 1}º ${item.nome}
 *Raridade:* ${item.raridade}
-*Preço:* ${item.preco}`
-            });
+*Preço:* ${item.preco}`;
+      });
 
-            const message = `*Inventário de* @${sender.split("@")[0]}\n\n${waifusInv.join("\n\n")}`;
-
-            await sock.sendMessage(from, {text: message, mentions: [sender]}, {quoted: msg});
-
-
-        }
-        catch(err) {
-            console.error(err);
-            await bot.reply(from, erros_prontos);
-        }
+      const message = `*Inventário de* @${sender.split("@")[0]}\n\n${waifusInv.join("\n\n")}`;
+      await sock.sendMessage(from, {text: message, mentions: [sender]}, {quoted: msg});
+    } catch(err) {
+      console.error(err);
+      await bot.reply(from, erros_prontos);
     }
-}
+  }
+};

--- a/src/commands/economia/xp.js
+++ b/src/commands/economia/xp.js
@@ -1,22 +1,17 @@
-const { users } = require("../../database/models/users.js");
+const { ensureUser } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "xp",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
-      
-      const user = await users.findOne({userLid: sender});
-      
+      const user = await ensureUser(sender, msg.pushName || "Sem nome");
       const pushname = msg?.pushName || "Sem nome";
-      
-      const image = `https://zero-two-apis.com.br/api/canvas/level?foto=https://files.catbox.moe/0ug48m&nome=${encodeURIComponent(pushname)}&expnow=${user?.xp}&expall=${user?.proximolevel}&level=${user?.level}&fundo=https://files.catbox.moe/b05qkn`
-      
+      const image = `https://zero-two-apis.com.br/api/canvas/level?foto=https://files.catbox.moe/0ug48m&nome=${encodeURIComponent(pushname)}&expnow=${user?.xp}&expall=${user?.proximolevel}&level=${user?.level}&fundo=https://files.catbox.moe/b05qkn`;
+
       await sock.sendMessage(from, {image: {url: image}}, {quoted: msg});
-      
-    }
-    catch(err) {
+    } catch(err) {
       await bot.reply(from, erros_prontos);
       console.error(err);
     }
   }
-}
+};

--- a/src/commands/geral/bot.js
+++ b/src/commands/geral/bot.js
@@ -10,18 +10,7 @@ module.exports = {
       
       const msgEspera = await bot.reply(from, espera_pronta);
       
-      const groups = await grupos.find();
-      
-      const gruposAtivos = groups.filter(g => {
-        const agoraMs = Date.now();
-        
-        if(g.aluguel) {
-        const vencimentoMs = g.aluguel.getTime();
-        
-        return vencimentoMs < agoraMs
-          
-        }
-      });
+      const gruposAtivos = await grupos.countDocuments({aluguel: {$gt: new Date()}});
       
       
       const ownerLink = `https://api.whatsapp.com/send/?phone=%2B558791732587&text=Oi,%20Speed&type=phone_number&app_absent=0&wame_ctl=1`
@@ -44,7 +33,7 @@ module.exports = {
 *Dono:* Speed
 > métricas
 *Processo:* ${horasProcess}h ${MinProcess}m ${segundosProcesso}s 
-*Grupos ativos:* ${gruposAtivos.length}
+*Grupos ativos:* ${gruposAtivos}
 *mensagens por minuto:* ${Number(msgMinuto) + 1}
 *Comandos por minuto*: ${Number(cmdMinuto) + 1}
 > Links

--- a/src/commands/geral/listadonos.js
+++ b/src/commands/geral/listadonos.js
@@ -6,9 +6,9 @@ module.exports = {
   async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
     try {
     //Busca todos os documentos
-    const donosTotal = await donos.find();
+    const donosTotal = await donos.find().lean();
     //caso nao exista NENHUM DONO
-    if(!donosTotal) {
+    if(!donosTotal.length) {
       await sock.sendMessage(from, {text: "Não há donos registrados."}, {quoted: msg});
       return;
     }

--- a/src/commands/geral/ping.js
+++ b/src/commands/geral/ping.js
@@ -21,8 +21,10 @@ module.exports = {
     
     const processador = os.cpus()[0]
     
-    const usersFind = await users.find();
-    const gruposFind = await grupos.find();
+    const [usersCount, gruposCount] = await Promise.all([
+      users.countDocuments(),
+      grupos.countDocuments()
+    ]);
 
 const infoPing = `⚡𝗣𝗶𝗻𝗴:${ping}ms
 💨𝗦𝗶𝘀𝘁𝗲𝗺𝗮 𝗼𝗽𝗲𝗿𝗮𝗰𝗶𝗼𝗻𝗮𝗹: ${os.type()}
@@ -36,8 +38,8 @@ const infoPing = `⚡𝗣𝗶𝗻𝗴:${ping}ms
 
 𝗕𝗼𝘁 𝗶𝗻𝗳𝗼:
 
-👻𝗨𝘀𝘂𝗮́𝗿𝗶𝗼𝘀: ${usersFind.length}
-💖𝗚𝗿𝘂𝗽𝗼𝘀: ${gruposFind.length}
+👻𝗨𝘀𝘂𝗮́𝗿𝗶𝗼𝘀: ${usersCount}
+💖𝗚𝗿𝘂𝗽𝗼𝘀: ${gruposCount}
 *Grupo:* https://chat.whatsapp.com/IbVzNXRCH2X8Oim6B4wKnP?mode=gi_t
 `
 

--- a/src/commands/geral/prefixo.js
+++ b/src/commands/geral/prefixo.js
@@ -1,10 +1,8 @@
-const { users } = require("../../database/models/users.js");
-
+const { ensureUser, updateUserAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "disable-prefix",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-    
     async function sendHelp() {
       await bot.reply(from, `*Como ativar o modo sem prefixo da Yuki:*
 
@@ -13,50 +11,42 @@ module.exports = {
 \`/disable-prefix 0\`
 > Desativa o modo sem prefixo`);
     }
-    
+
     try {
-      
-      
-      
-      const user = await users.findOne({userLid: sender});
-      
+      const user = await ensureUser(sender, msg.pushName || "Sem nome");
       const argumentos = Number(args[0]);
-      
-      if(argumentos === undefined) {
-        sendHelp();
-        return
+
+      if(args[0] === undefined) {
+        await sendHelp();
+        return;
       }
-      
+
       if(argumentos === 0) {
         if(user.prefixo) {
           await bot.reply(from, "Você já está com o modo sem prefixo desativado!");
-          return
+          return;
         }
-        
-        await users.updateOne({userLid: sender}, {$set: {prefixo: true}}, {upsert: true});
-        
+
+        await updateUserAndCache(sender, {$set: {prefixo: true}});
         await bot.reply(from, "Modo sem prefixo desativado com sucesso!");
-        
+        return;
       }
-      else if(argumentos === 1) {
-      if(!user.prefixo) {
-        await bot.reply(from, "Você já está com o modo sem prefixo ativado!");
-        return
+
+      if(argumentos === 1) {
+        if(!user.prefixo) {
+          await bot.reply(from, "Você já está com o modo sem prefixo ativado!");
+          return;
+        }
+
+        await updateUserAndCache(sender, {$set: {prefixo: false}});
+        await bot.reply(from, "Modo sem prefixo ativado com sucesso!");
+        return;
       }
-      
-      await users.updateOne({userLid: sender}, {$set: {prefixo: false}}, {upsert: true});
-      
-      await bot.reply(from, "Modo sem prefixo ativado com sucesso!");
+
+      await sendHelp();
+    } catch(err) {
+      await bot.reply(from, erros_prontos);
+      console.error(err);
     }
-    else {
-      sendHelp();
-    }
-    
   }
-  catch(err) {
-    await bot.reply(from, erros_prontos);
-    console.error(err);
-  }
-  
-}
-}
+};

--- a/src/commands/geral/sticker.js
+++ b/src/commands/geral/sticker.js
@@ -6,8 +6,8 @@ const { downloadMediaMessage } = require('whaileys');
 const fs = require('fs')
 const { exec } = require('child_process')
 const { version } = require("../../config");
-const { users } = require("../../database/models/users");
 const { normalizeUserLid } = require("../../utils/normalizeUserLid");
+const { updateUserAndCache } = require("../../utils/dbHelpers");
 
 
 module.exports = {
@@ -131,7 +131,7 @@ const subdados = `↦ ✨𝑭𝒆𝒊𝒕𝒐 𝒑𝒐𝒓: ${pushname} • ${ti
       
       await sock.sendMessage(jid, { sticker: stickerBuffer }, { quoted: msg });
       
-      await users.updateOne({userLid: normalizeUserLid(sender)}, {$inc: {figurinhas: 1}});
+      await updateUserAndCache(normalizeUserLid(sender), {$inc: {figurinhas: 1}});
 
       await fs.unlinkSync(inputPath);
       await fs.unlinkSync(outputPath);

--- a/src/commands/grupo/afk.js
+++ b/src/commands/grupo/afk.js
@@ -1,72 +1,57 @@
-const { grupos } = require("../../database/models/grupos.js");
-
+const { ensureGroupFromSocket, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "afkmode",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     async function sendHelp() {
-  await sock.sendMessage(from, {
-    text: `*Como usar comandos de opção:*\n0 - Desativado | Desligado\n>\nExemplo: "/welcome 0"\n1 - Ativado | Ligado\n> Exemplo: "/welcome 1"`
-  }, { quoted: msg });
-}
+      await sock.sendMessage(from, {
+        text: `*Como usar comandos de opção:*\n0 - Desativado | Desligado\n>\nExemplo: "/welcome 0"\n1 - Ativado | Ligado\n> Exemplo: "/welcome 1"`
+      }, { quoted: msg });
+    }
+
     try {
-      
       if(!from.endsWith("@g.us")) {
         await bot.reply(from, "Use esse comando em um grupo!");
-        return
+        return;
       }
-      
-      
-      
-      const grupo = await grupos.findOne({groupId: from});
+
+      const grupo = await ensureGroupFromSocket(sock, from);
       const afkList = Array.isArray(grupo?.afkList) ? grupo.afkList : [];
       const rawParam = args?.[0];
 
       if(rawParam === undefined) {
         await sendHelp();
-        return
+        return;
       }
-      
+
       const parametro = Number(rawParam);
-      
+
       if(!Number.isInteger(parametro) || (parametro !== 0 && parametro !== 1)) {
         await sendHelp();
-        return
+        return;
       }
-      
-      //desativa o modo afk
+
       if(parametro === 0) {
         if(!afkList.includes(sender)) {
           await bot.reply(from, "Você já está com o afkmode desativado!");
-          return
+          return;
         }
-        
-        await grupos.updateOne({groupId: from}, {$pull: {afkList: sender}}, {upsert: true});
-        
+
+        await updateGroupAndCache(from, {$pull: {afkList: sender}});
         await bot.reply(from, "Modo afk desativado. Notificação de adms de volta!");
+        return;
       }
-      
-      else if(parametro === 1) {
-        if(afkList.includes(sender)) {
-          await bot.reply(from, "Você já está com o afkmode ativado!");
-          return
-        }
-        
-        await grupos.updateOne({groupId: from}, {$addToSet: {afkList: sender}}, {upsert: true});
-        
-        await bot.reply(from, "afkmode ativado! Agora as totags estaram silenciosas para você.");
-        
+
+      if(afkList.includes(sender)) {
+        await bot.reply(from, "Você já está com o afkmode ativado!");
+        return;
       }
-      else {
-        await sendHelp();
-      }
-      
-      
-    }
-    catch(err) {
+
+      await updateGroupAndCache(from, {$addToSet: {afkList: sender}});
+      await bot.reply(from, "afkmode ativado! Agora as totags estaram silenciosas para você.");
+    } catch(err) {
       await bot.reply(from, erros_prontos);
       console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/grupo/antiTotag.js
+++ b/src/commands/grupo/antiTotag.js
@@ -1,5 +1,4 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { ensureGroup, getGroupPermission, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "antimarcar",
@@ -17,25 +16,14 @@ module.exports = {
         return
       }
       
-      const metadata = await sock.groupMetadata(from);
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
       
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const donim = await donos.findOne({userLid: sender});
-      
-      if (!isAdmin.includes(sender) && !donim) {
+      if (!allowed) {
         await bot.sendNoAdmin();
         return
       }
       
-      const grupoDb = await grupos.findOne({groupId: from});
-      
-      
-      if (!grupoDb) {
-        await grupos.create({groupId: from});
-      }
+      await ensureGroup(from, metadata);
       
       const options = args[0]?.trim();
       
@@ -45,14 +33,14 @@ module.exports = {
       }
       
       if(options === "0") {
-        await grupos.updateOne({groupId: from}, {$set: {antiTotag: false}}, {upsert: true});
+        await updateGroupAndCache(from, {$set: {antiTotag: false}}, {metadata});
         
         await bot.reply(from, "Anti marcação desativado com sucesso. Agora podem fazer a festa!");
         return
       }
       
       else if(options === "1") {
-        await grupos.updateOne({groupId: from}, {$set: {antiTotag: true}}, {upsert: true});
+        await updateGroupAndCache(from, {$set: {antiTotag: true}}, {metadata});
         
        await bot.reply(from, "Anti marcação ativada. Chega de bagunça!");
         return

--- a/src/commands/grupo/antilink.js
+++ b/src/commands/grupo/antilink.js
@@ -1,5 +1,4 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { ensureGroup, getGroupPermission, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 
 
@@ -21,25 +20,14 @@ module.exports = {
         return
       }
       
-      const metadata = await sock.groupMetadata(from);
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
       
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const donim = await donos.findOne({userLid: sender});
-      
-      if (!isAdmin.includes(sender) && !donim) {
+      if (!allowed) {
         await sock.sendMessage(from, {text: "Comando restrito a admins"}, {quoted: msg});
         return
       }
       
-      const grupoDb = await grupos.findOne({groupId: from});
-      
-      
-      if (!grupoDb) {
-        await grupos.create({groupId: from});
-      }
+      await ensureGroup(from, metadata);
       
       const options = args[0]?.trim();
       
@@ -49,14 +37,14 @@ module.exports = {
       }
       
       if(options === "0") {
-        await grupos.updateOne({groupId: from}, {$set: {"configs.antlink": false}});
+        await updateGroupAndCache(from, {$set: {"configs.antlink": false}}, {metadata});
         
         await sock.sendMessage(from, {text: "Antilink desligado!"}, {quoted: msg});
         return
       }
       
       else if(options === "1") {
-        await grupos.updateOne({groupId: from}, {$set: {"configs.antlink": true}});
+        await updateGroupAndCache(from, {$set: {"configs.antlink": true}}, {metadata});
         
         await sock.sendMessage(from, {text: "Antilink Ligado!"}, {quoted: msg});
         return

--- a/src/commands/grupo/autoDonwload.js
+++ b/src/commands/grupo/autoDonwload.js
@@ -1,5 +1,4 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { ensureGroup, getGroupPermission, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "autodownload",
@@ -17,25 +16,14 @@ module.exports = {
         return
       }
       
-      const metadata = await sock.groupMetadata(from);
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
       
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const donim = await donos.findOne({userLid: sender});
-      
-      if (!isAdmin.includes(sender) && !donim) {
+      if (!allowed) {
         await sock.sendMessage(from, {text: "Comando restrito a admins"}, {quoted: msg});
         return
       }
       
-      const grupoDb = await grupos.findOne({groupId: from});
-      
-      
-      if (!grupoDb) {
-        await grupos.create({groupId: from});
-      }
+      await ensureGroup(from, metadata);
       
       const options = args[0]?.trim();
       
@@ -45,14 +33,14 @@ module.exports = {
       }
       
       if(options === "0") {
-        await grupos.updateOne({groupId: from}, {$set: {autoDownload: false}});
+        await updateGroupAndCache(from, {$set: {autoDownload: false}}, {metadata});
         
         await sock.sendMessage(from, {text: "Auto download desativado com sucesso!"}, {quoted: msg});
         return
       }
       
       else if(options === "1") {
-        await grupos.updateOne({groupId: from}, {$set: {autoDownload: true}});
+        await updateGroupAndCache(from, {$set: {autoDownload: true}}, {metadata});
         
         await sock.sendMessage(from, {text: "Auto donwload ativado!"}, {quoted: msg});
         return

--- a/src/commands/grupo/autoReply.js
+++ b/src/commands/grupo/autoReply.js
@@ -1,5 +1,4 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { ensureGroup, getGroupPermission, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "autoreply",
@@ -17,25 +16,14 @@ module.exports = {
         return
       }
       
-      const metadata = await sock.groupMetadata(from);
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
       
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const donim = await donos.findOne({userLid: sender});
-      
-      if (!isAdmin.includes(sender) && !donim) {
+      if (!allowed) {
         await sock.sendMessage(from, {text: "Comando restrito a admins"}, {quoted: msg});
         return
       }
       
-      const grupoDb = await grupos.findOne({groupId: from});
-      
-      
-      if (!grupoDb) {
-        await grupos.create({groupId: from});
-      }
+      await ensureGroup(from, metadata);
       
       const options = args[0]?.trim();
       
@@ -45,14 +33,14 @@ module.exports = {
       }
       
       if(options === "0") {
-        await grupos.updateOne({groupId: from}, {$set: {autoReply: false}});
+        await updateGroupAndCache(from, {$set: {autoReply: false}}, {metadata});
         
         await sock.sendMessage(from, {text: "AutoReply desligado!"}, {quoted: msg});
         return
       }
       
       else if(options === "1") {
-        await grupos.updateOne({groupId: from}, {$set: {autoReply: true}});
+        await updateGroupAndCache(from, {$set: {autoReply: true}}, {metadata});
         
         await sock.sendMessage(from, {text: "Autoreply funcionando!"}, {quoted: msg});
         return

--- a/src/commands/grupo/grupoInfo.js
+++ b/src/commands/grupo/grupoInfo.js
@@ -1,52 +1,39 @@
-const { grupos } = require("../../database/models/grupos");
 const path = require("path");
 const { clientRedis } = require("../../lib/redis.js");
+const { ensureGroup } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "grupoinfo",
-  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
-    
+  async execute(sock, msg, from, args, erros_prontos) {
     try {
-      
       if (msg.key.remoteJid.endsWith("@lid")) {
         await sock.sendMessage(from, {text: "Use esse comando dentro de um grupo."}, {quoted: msg});
-        return
+        return;
       }
-      
-      const grupoDb = await grupos.findOne({groupId: from});
-      
-      
-      
-      if (!grupoDb) {
-        await grupos.create({groupId: from});
-      }
-      
-      await sock.sendMessage(from, {text: "Buscando por infomações do grupo..."}, {quoted: msg});
-      
+
+      await sock.sendMessage(from, {text: "Buscando por informações do grupo..."}, {quoted: msg});
+
       const metadata = await sock.groupMetadata(from);
-      
-      const vencimentoMs = grupoDb?.aluguel?.getTime();
+      const grupoDb = await ensureGroup(from, metadata);
+
+      const vencimentoMs = grupoDb?.aluguel?.getTime?.() || Date.now();
       const agora = Date.now();
-      
-      const restanteMs = vencimentoMs - agora
-      
+      const restanteMs = vencimentoMs - agora;
       const restanteDias = Math.max(0, Math.ceil(restanteMs / (24 * 60 * 60 * 1000)));
-      
       const restanteHoras = Math.max(0, Math.floor(restanteMs / (60 * 60 * 1000)));
-      
       const metricsMessage = await clientRedis.get(`message:min:${from}`);
-      
-      const info = `𝗜𝗻𝗳𝗼𝗿𝗺𝗮𝗰̧𝗼̃𝗲𝘀 𝗱𝗼 𝗴𝗿𝘂𝗽𝗼
+
+      const info = `𝗜𝗻𝗳𝗼𝗿𝗺𝗮çõ𝗲𝘀 𝗱𝗼 𝗴𝗿𝘂𝗽𝗼
 ⤷ *Nome:* ${metadata.subject}
 ⤷ *Id:* ${from.split("@")[0]}
 ⤷ *Vence em:* ${grupoDb?.aluguel.toLocaleDateString("pt-BR")} - Faltam ${restanteDias || 0} Dias e ${restanteHoras || 0} Horas
 ⤷ *Comandos usados:* ${grupoDb.cmdUsados}
 
-𝗠𝗲́𝘁𝗿𝗶𝗰𝗮𝘀
+𝗠é𝘁𝗿𝗶𝗰𝗮𝘀
 
 ⤷ *mensagens por minuto:* ${metricsMessage}
 
-𝗖𝗼𝗻𝗳𝗶𝗴𝘂𝗿𝗮𝗰̧𝗼̃𝗲𝘀
+𝗖𝗼𝗻𝗳𝗶𝗴𝘂𝗿𝗮çõ𝗲𝘀
 
 ⤷ *eventos:* ${grupoDb.configs?.events ? "On" : "Off"}
 ⤷ *bem-vindo:* ${grupoDb.configs?.welcome ? "On" : "Off"}
@@ -54,24 +41,20 @@ module.exports = {
 ⤷ *auto-resposta:* ${grupoDb?.autoReply ? "On" : "Off"}
 ⤷ *Modo brincadeira:* ${grupoDb?.configs?.cmdFun ? "On" : "Off"}
 ⤷ *Auto-Download:* ${grupoDb?.autoDownload ? "On" : "Off"}
-⤷ *Anti-spam de marcação:* ${grupoDb?.antiTotag ? "On" : "Off"}`
-      
-      
+⤷ *Anti-spam de marcação:* ${grupoDb?.antiTotag ? "On" : "Off"}`;
+
       let groupImage;
-      
+
       try {
         groupImage = await sock.profilePictureUrl(from, "image");
       } catch(err) {
         groupImage = path.join(__dirname, "../../assets/images/yukipfp/yukiOclin2.jpg");
       }
-      
+
       await sock.sendMessage(from, {image: {url: groupImage}, caption: info}, {quoted: msg});
-      
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
-      console.error(err)
+      console.error(err);
     }
-    
   }
-}
+};

--- a/src/commands/grupo/gruposRank.js
+++ b/src/commands/grupo/gruposRank.js
@@ -8,7 +8,7 @@ module.exports = {
       
       const msgEspera = await sock.sendMessage(from, {text: "Buscando rank dos grupos..."}, {quoted: msg});
       
-      const group = await grupos.find().sort({cmdUsados: -1 }).limit(10);
+      const group = await grupos.find().sort({cmdUsados: -1 }).limit(10).lean();
       
       const rankMap = group.map((item, indice) => {
         return `\`${indice + 1}. ${item.grupoName}\`\n ⤷ Cmd usados: ${item.cmdUsados}`

--- a/src/commands/grupo/modoBrincadeira.js
+++ b/src/commands/grupo/modoBrincadeira.js
@@ -1,5 +1,4 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { ensureGroup, getGroupPermission, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "modobrincadeira",
@@ -17,25 +16,14 @@ module.exports = {
         return
       }
       
-      const metadata = await sock.groupMetadata(from);
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
       
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.lid);
-      
-      
-      
-      const donim = await donos.findOne({userLid: sender});
-      
-      if (!isAdmin.includes(sender) && !donim) {
+      if (!allowed) {
         await sock.sendMessage(from, {text: "Comando restrito a admins"}, {quoted: msg});
         return
       }
       
-      const grupoDb = await grupos.findOne({groupId: from});
-      
-      
-      if (!grupoDb) {
-        await grupos.create({groupId: from});
-      }
+      await ensureGroup(from, metadata);
       
       const options = args[0]?.trim();
       
@@ -45,14 +33,14 @@ module.exports = {
       }
       
       if(options === "0") {
-        await grupos.updateOne({groupId: from}, {$set: {"configs.cmdFun": false}});
+        await updateGroupAndCache(from, {$set: {"configs.cmdFun": false}}, {metadata});
         
         await sock.sendMessage(from, {text: "Modo brincadeira desativado!"}, {quoted: msg});
         return
       }
       
       else if(options === "1") {
-        await grupos.updateOne({groupId: from}, {$set: {"configs.cmdFun": true}});
+        await updateGroupAndCache(from, {$set: {"configs.cmdFun": true}}, {metadata});
         
         await sock.sendMessage(from, {text: "Modo brincadeira ativo!"}, {quoted: msg});
         return

--- a/src/commands/grupo/mudarprefix.js
+++ b/src/commands/grupo/mudarprefix.js
@@ -1,54 +1,35 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
-
-
+const { ensureGroup, getGroupPermission, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 module.exports = {
   name: "alterarprefixo",
-  async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
     try {
       const prefixEscolhido = args[0];
-      const metadados = await sock.groupMetadata(from);
-      const Admins = metadados.participants.filter(p => p.admin);
-      const groupAdmins = Admins.map(m => m.id);
-      const sender = msg.key.participant
-      
-      const doninhos = await donos.findOne({userLid: sender});
-      
-      if(!groupAdmins.includes(sender) && !doninhos) {
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender || msg.key.participant);
+
+      if (!allowed) {
         await sock.sendMessage(from, {text: "Só quem pode mudar o prefixo é um admin!"}, {quoted: msg});
-        return
+        return;
       }
-      
-      
-      
-      if(!await grupos.findOne({groupId: from})) {
-        await grupos.create({groupId: from})
-      }
-      
-      if(prefixEscolhido.length >1) {
-        await sock.sendMessage(from, {text: "Passou de 1 caractere porra."}, {quoted: msg});
-        return
-      }
-      
-      if(!prefixEscolhido) {
+
+      await ensureGroup(from, metadata);
+
+      if (!prefixEscolhido) {
         await sock.sendMessage(from, {text: "Cadê o prefixo? Zé bct"}, {quoted: msg});
-        return
+        return;
       }
-      
+
+      if (prefixEscolhido.length > 1) {
+        await sock.sendMessage(from, {text: "Passou de 1 caractere porra."}, {quoted: msg});
+        return;
+      }
+
       await sock.sendMessage(from, {text: "Alterando prefixo..."}, {quoted: msg});
-      
-      await grupos.updateOne({groupId: from}, {$set: {"configs.prefixo": prefixEscolhido}});
-      
+      await updateGroupAndCache(from, {$set: {"configs.prefixo": prefixEscolhido}}, {metadata});
       await sock.sendMessage(from, {text: `Prefixo alterado para: \`${prefixEscolhido}\``}, {quoted: msg});
-  
-      
-    }
-    catch(err) {
+    } catch(err) {
       await sock.sendMessage(from, {text: erros_prontos}, {quoted: msg});
-      console.error(err)
+      console.error(err);
     }
-    
-    
   }
-}
+};

--- a/src/commands/grupo/rankativos.js
+++ b/src/commands/grupo/rankativos.js
@@ -4,7 +4,7 @@ module.exports = {
   name: "rankativos",
   async execute(sock, msg, from, args, erros_prontos, espera_pronta) {
     try {
-      const array = await rankativos.find({from: from}).sort({msg: -1}).limit(10);
+      const array = await rankativos.find({from: from}).sort({msg: -1}).limit(10).lean();
       
       const list = array.map((item, indice) => {
         return `❛❛.𔓘᷼${indice + 1} ➻ @${item.userLid.split("@")[0]}\n𝗺𝗲𝗻𝘀𝗮𝗴𝗲𝗻𝘀: ${item.msg}

--- a/src/commands/grupo/welcome.js
+++ b/src/commands/grupo/welcome.js
@@ -1,5 +1,4 @@
-const { grupos } = require("../../database/models/grupos");
-const { donos } = require("../../database/models/donos");
+const { ensureGroup, getGroupPermission, updateGroupAndCache } = require("../../utils/dbHelpers");
 
 
 
@@ -21,25 +20,14 @@ module.exports = {
         return
       }
       
-      const metadata = await sock.groupMetadata(from);
+      const { metadata, allowed } = await getGroupPermission(sock, from, sender);
       
-      const isAdmin = metadata.participants.filter(p => p.admin).map(p => p.id);
-      
-      
-      
-      const donim = await donos.findOne({userLid: sender});
-      
-      if (!isAdmin.includes(sender) && !donim) {
+      if (!allowed) {
         await sock.sendMessage(from, {text: "Comando restrito a admins"}, {quoted: msg});
         return
       }
       
-      const grupoDb = await grupos.findOne({groupId: from});
-      
-      
-      if (!grupoDb) {
-        await grupos.create({groupId: from});
-      }
+      await ensureGroup(from, metadata);
       
       const options = args[0]?.trim();
       
@@ -49,14 +37,14 @@ module.exports = {
       }
       
       if(options === "0") {
-        await grupos.updateOne({groupId: from}, {$set: {"configs.welcome": false}});
+        await updateGroupAndCache(from, {$set: {"configs.welcome": false}}, {metadata});
         
         await sock.sendMessage(from, {text: "Welcome desligado!"}, {quoted: msg});
         return
       }
       
       else if(options === "1") {
-        await grupos.updateOne({groupId: from}, {$set: {"configs.welcome": true}});
+        await updateGroupAndCache(from, {$set: {"configs.welcome": true}}, {metadata});
         
         await sock.sendMessage(from, {text: "Welcome Ligado!"}, {quoted: msg});
         return

--- a/src/database/models/adverts.js
+++ b/src/database/models/adverts.js
@@ -7,6 +7,8 @@ const schema = new mongoose.Schema({
   adv: {type: Number, default: 0}
 });
 
+schema.index({ userLid: 1, grupo: 1 });
+
 const advertidos = mongoose.model("adv", schema)
 
 module.exports = {

--- a/src/database/models/donos.js
+++ b/src/database/models/donos.js
@@ -1,8 +1,8 @@
 const mongoose = require("mongoose");
 
 const schema = new mongoose.Schema({
-  userLid: {type: String, require: true},
-  data: {type: Date, default: new Date},
+  userLid: {type: String, required: true, index: true},
+  data: {type: Date, default: Date.now},
   desc: {type: String, default: "Oi!"}
   
 });

--- a/src/database/models/grupos.js
+++ b/src/database/models/grupos.js
@@ -1,10 +1,10 @@
 const mongoose = require("mongoose");
 
 const schema = new mongoose.Schema({
-  groupId: {type: String, required: true},
+  groupId: {type: String, required: true, index: true},
   grupoName: {type: String, required: true},
   ownerId: {type: String, required: true},
-  aluguel: {type: Date, default: Date.now()},
+  aluguel: {type: Date, default: Date.now},
   configs: {
     events: {type: Boolean, default: true},
     prefixo: {type: String, default: "/"},
@@ -24,6 +24,9 @@ const schema = new mongoose.Schema({
   
   
 });
+
+schema.index({ aluguel: 1 });
+schema.index({ cmdUsados: -1 });
 
 const grupos = mongoose.model("grupos", schema);
 

--- a/src/database/models/mute.js
+++ b/src/database/models/mute.js
@@ -7,6 +7,8 @@ const model = new mongoose.Schema({
   tentativasMsg: {type: Number, default: 0}
 });
 
+model.index({ userLid: 1, grupo: 1 });
+
 const mutados = mongoose.model('mutado', model);
 
 module.exports = {

--- a/src/database/models/rankativos.js
+++ b/src/database/models/rankativos.js
@@ -7,6 +7,9 @@ const schema = new mongoose.Schema({
   from: {type: String, required: true}
 });
 
+schema.index({ userLid: 1, from: 1 });
+schema.index({ from: 1, msg: -1 });
+
 const rankativos = mongoose.model("rankAtivo", schema);
 
 module.exports = {

--- a/src/database/models/users.js
+++ b/src/database/models/users.js
@@ -1,13 +1,22 @@
 const mongoose = require("mongoose");
 
-
 const userSchema = new mongoose.Schema({
   userLid: {type: String, required: true, unique: true},
   name: {type: String, required: true},
   bio: {type: String, default: "Olá, amo a Yuki!"},
+  grupos: [{
+    id: {type: String},
+    nome: {type: String}
+  }],
+  discord_id: {type: String, default: null},
+  discord_name: {type: String, default: null},
+  spotifyToken: {
+    refresh: {type: String, default: null},
+    token: {type: String, default: null}
+  },
   isVip: {type: Boolean, default: false},
-  vencimentoVip: {type: Date, default: new Date()},
-  registro: {type: Date, default: new Date()},
+  vencimentoVip: {type: Date, default: Date.now},
+  registro: {type: Date, default: Date.now},
   casal: {
     parceiro: {type: String, default: null},
     pedido: {type: Date, default: null},
@@ -26,8 +35,13 @@ const userSchema = new mongoose.Schema({
   proximolevel: {type: Number, default: 100}
 });
 
+userSchema.index({ cmdCount: -1 });
+userSchema.index({ dinheiro: -1 });
+userSchema.index({ level: -1 });
+userSchema.index({ discord_id: 1 });
+
 const users = mongoose.model("User", userSchema);
 
 module.exports = {
   users
-}
+};

--- a/src/events/messages.js
+++ b/src/events/messages.js
@@ -1,9 +1,7 @@
 const { prefixo, numberBot, numberBotJid } = require("../config.js");
-const connectDB = require("../lib/mongoDB.js");
 const similarityCmd = require("../utils/similaridadeCmd");
 const { users } = require("../database/models/users");
 const { donos } = require("../database/models/donos");
-const { rankativos } = require("../database/models/rankativos");
 const { grupos } = require("../database/models/grupos");
 const instaDl = require("../utils/instagram");
 const { mutados } = require("../database/models/mute");
@@ -20,6 +18,106 @@ const addXp = require("../utils/xp.js");
 const YukiAI = require("../ai.js");
 const { normalizeUserLid } = require("../utils/normalizeUserLid");
 const { isOwnerLid } = require("../utils/owner");
+const { groupCache, muteCache, ownerCache, userCache } = require("../utils/hotPathCache");
+const {
+  createMessageMongoMetrics,
+  finishMessageMongoMetrics,
+  markQueuedWrite,
+  trackMongo
+} = require("../utils/messageMongoMetrics");
+const { queueCommandActivity, queueMessageActivity } = require("../utils/statsBatcher");
+const {
+  invalidateMute,
+  muteCacheKey,
+  setMuteCache,
+  updateUserAndCache
+} = require("../utils/dbHelpers");
+
+const NULL_CACHE_TTL_MS = 5 * 1000;
+const OWNER_NEGATIVE_CACHE_TTL_MS = 60 * 1000;
+const pendingUserLoads = new Map();
+const pendingGroupLoads = new Map();
+const pendingOwnerLoads = new Map();
+
+async function oncePerKey(map, key, loader) {
+  if (map.has(key)) return map.get(key);
+
+  const promise = loader().finally(() => {
+    map.delete(key);
+  });
+
+  map.set(key, promise);
+  return promise;
+}
+
+async function ensureCachedUser(sender, pushName, metrics) {
+  const user = await oncePerKey(pendingUserLoads, `ensure:${sender}`, () =>
+    trackMongo(metrics, "users.findOneAndUpdate:ensure", () =>
+      users.findOneAndUpdate(
+        { userLid: sender },
+        { $setOnInsert: { userLid: sender, name: pushName || "Sem nome" } },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      ).lean()
+    )
+  );
+
+  userCache.set(sender, user || null);
+  return user;
+}
+
+async function getCachedGroup(groupId, metrics) {
+  const cached = groupCache.get(groupId);
+  if (cached !== undefined) return cached;
+
+  const group = await oncePerKey(pendingGroupLoads, `get:${groupId}`, () =>
+    metrics
+      ? trackMongo(metrics, "grupos.findOne:group", () =>
+        grupos.findOne({ groupId }).lean()
+      )
+      : grupos.findOne({ groupId }).lean()
+  );
+
+  groupCache.set(groupId, group || null, group ? undefined : NULL_CACHE_TTL_MS);
+  return group;
+}
+
+async function ensureCachedGroup(sock, groupId, metrics) {
+  const group = await oncePerKey(pendingGroupLoads, `ensure:${groupId}`, async () => {
+    const groupDados = await sock.groupMetadata(groupId);
+
+    return trackMongo(metrics, "grupos.findOneAndUpdate:ensure", () =>
+      grupos.findOneAndUpdate(
+        { groupId },
+        {
+          $setOnInsert: {
+            groupId,
+            grupoName: groupDados.subject || "Sem nome",
+            ownerId: groupDados?.owner || "Sem dono"
+          }
+        },
+        { upsert: true, new: true, setDefaultsOnInsert: true }
+      ).lean()
+    );
+  });
+
+  groupCache.set(groupId, group || null);
+  return group;
+}
+
+async function getCachedOwner(sender, metrics) {
+  const cached = ownerCache.get(sender);
+  if (cached !== undefined) return cached;
+
+  const owner = await oncePerKey(pendingOwnerLoads, sender, () =>
+    trackMongo(metrics, "donos.findOne:sender", () =>
+      donos.findOne({ userLid: sender }).lean()
+    )
+  );
+
+  const isOwner = !!owner;
+  ownerCache.set(sender, isOwner, isOwner ? undefined : OWNER_NEGATIVE_CACHE_TTL_MS);
+  return isOwner;
+}
 
 async function safeRedis(action, fallback = null) {
   if (!clientRedis?.isOpen) return fallback;
@@ -366,7 +464,7 @@ async function safeRedis(action, fallback = null) {
         activeInterval.delete(from);
 
         try {
-          const freshGroup = await grupos.findOne({ groupId: from });
+          const freshGroup = await getCachedGroup(from);
           if (!freshGroup?.autoReply) return;
 
           const currentState = getAiState(from);
@@ -528,6 +626,10 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
     const from = msg?.key?.remoteJid || msg?.key?.participantLid
     if (!from || !sender) return;
+
+    const mongoMetrics = createMessageMongoMetrics({ from, sender });
+
+    try {
     
     
     
@@ -569,25 +671,46 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
 
     
 
-    let doninhos = false;
-
-    const ownerCache = await clientRedis.hGetAll(`ownerCache:${sender}`);
-
-    if (Object.keys(ownerCache).length === 0) { 
-      const isOwner = await donos.findOne({ userLid: sender });
-
-      if (isOwner) {
-        doninhos = true;
-        await clientRedis.hSet(`ownerCache:${sender}`, { isOwner: "true" });
-        }
-        else {
-          await clientRedis.hSet(`ownerCache:${sender}`, { isOwner: "false" });
-          await clientRedis.expire(`ownerCache:${sender}`, 3600);
-          doninhos = false;
-        }
-    }
-    
     const bot = new YukiBot({sock: sock, msg});
+    const isGroup = from.endsWith("@g.us");
+    const isPrivate = from.endsWith("@lid");
+    let ownerPromise = null;
+
+    const getOwner = () => {
+      if (!ownerPromise) ownerPromise = getCachedOwner(sender, mongoMetrics);
+      return ownerPromise;
+    };
+
+    const body = (msg.message?.conversation) ||
+    (msg.message?.extendedTextMessage?.text) ||
+    (msg.message?.imageMessage?.caption) ||
+    (msg.message?.documentMessage?.caption) || msg?.message?.buttonsResponseMessage?.selectedButtonId || "Msg estranha...";
+
+    const bodyCase = body.toLowerCase();
+
+    //argumentos
+    const args = body.slice(prefixo.length).trim().split(/ +/);
+    const isPrefixCommand = body.startsWith(prefixo);
+    const noPrefixPreview = isPrefixCommand ? [] : body.trim().split(/ +/);
+    const noPrefixCommandName = (noPrefixPreview[0] || "").toLowerCase();
+    const noPrefixCommandCandidate = noPrefixCommandName ? commandsMap.get(noPrefixCommandName) : null;
+
+    let usersSender = null;
+    let userLoaded = false;
+
+    async function getUsersSender() {
+      if (userLoaded) return usersSender;
+
+      const cachedUser = userCache.get(sender);
+      if(cachedUser) {
+        usersSender = cachedUser;
+      } else {
+        usersSender = await ensureCachedUser(sender, msg.pushName, mongoMetrics);
+      }
+
+      userLoaded = true;
+      return usersSender;
+    }
     
     await safeRedis(() => clientRedis.incr("metrics:message:min"));
     await safeRedis(() => clientRedis.expire("metrics:message:min", 60));
@@ -598,12 +721,11 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
 
     //Se uma mensagem Nao vier de um grupo entao ele pausa os comandos
-    //user
-    let usersSender = await users.findOne({userLid: sender});
-    
-    //const Notvip = !usersSender?.vencimentoVip || Date.now() > usersSender?.vencimentoVip?.getTime();
-    
-    if(from.endsWith("@lid") && !doninhos) {
+    if(isPrivate) {
+      const privateUser = await getUsersSender();
+      const Notvip = !privateUser?.vencimentoVip || Date.now() > privateUser?.vencimentoVip?.getTime();
+
+      if(!(await getOwner()) && Notvip) {
       
       const IsMsgPV = await safeRedis(() => clientRedis.exists(`pv:block:${sender}`), 0);
       
@@ -616,13 +738,18 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       await safeRedis(() => clientRedis.expire(`pv:block:${sender}`, 2 * 60));
       
       return;
+      }
     }
-    //se uma mensagem for de um grupo registra.
-    if(from.endsWith("@g.us")) {
+    let groupDBInfo = null;
 
-      const grupoDBInfo = await grupos.findOne({groupId: from})
+    //se uma mensagem for de um grupo registra.
+    if(isGroup) {
+
+      groupDBInfo = await getCachedGroup(from, mongoMetrics)
       //verifica se é adm
-      const isAdmRegistrado = usersSender?.grupos?.some(grupo => grupo.id === from);
+      if(isPrefixCommand || noPrefixCommandCandidate) {
+      const commandUser = await getUsersSender();
+      const isAdmRegistrado = commandUser?.grupos?.some(grupo => grupo.id === from);
 
       if(!isAdmRegistrado) {
         const isAdminSender = await bot.isAdmin(from);
@@ -631,19 +758,27 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
           try {
             const groupDados = await sock.groupMetadata(from);
 
-            await users.updateOne({userLid: sender}, {$addToSet: {grupos: {id: from, nome: groupDados.subject}}}, {upsert: true})
+            const updatedUser = await trackMongo(mongoMetrics, "users.findOneAndUpdate:adminGroup", () =>
+              updateUserAndCache(
+                sender,
+                {$addToSet: {grupos: {id: from, nome: groupDados.subject}}},
+                {upsert: true, name: msg.pushName || "Sem nome"}
+              )
+            );
+
+            usersSender = updatedUser?.toObject?.() || updatedUser || commandUser;
+            userLoaded = true;
           } catch(err) {
             console.error("Erro ao salvar grupo do admin:", err?.data || err?.message || err);
           }
         }
       }
+      }
       
-      if(!grupoDBInfo) {
+      if(!groupDBInfo) {
         
         try {
-          const groupDados = await sock.groupMetadata(from);
-        
-          await grupos.create({groupId: from, grupoName: groupDados.subject, ownerId: groupDados?.owner || "Sem dono"});
+          groupDBInfo = await ensureCachedGroup(sock, from, mongoMetrics);
         } catch(err) {
           console.error("Erro ao registrar grupo:", err?.data || err?.message || err);
         }
@@ -651,35 +786,50 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       
     }
     
-
-    const groupDBInfo = await grupos.findOne({groupId: from});
-    
-    
-
-    if(!await users.findOne({userLid: sender})) {
-      await users.create({userLid: sender, name: msg.pushName || "Sem nome"});
-      
-      usersSender = await users.findOne({userLid: sender})
-    }
-
-    await rankativos.updateOne({userLid: sender, from: from}, {$inc: {msg: 1}}, {upsert: true})
+    queueMessageActivity(sender, from);
+    markQueuedWrite(mongoMetrics);
 
      //se estiver alguem mutado
-    if(await mutados.findOne({userLid: sender, grupo: from})) {
+    let userMutado = null;
+    if(isGroup) {
+      const cachedMute = muteCache.get(muteCacheKey(sender, from));
+      if(cachedMute !== undefined) {
+        userMutado = cachedMute;
+      } else {
+        userMutado = await trackMongo(mongoMetrics, "mutados.findOne:message", () =>
+          mutados.findOne({userLid: sender, grupo: from}).lean()
+        );
+        muteCache.set(
+          muteCacheKey(sender, from),
+          userMutado || null,
+          userMutado ? undefined : Number(process.env.MUTE_NEGATIVE_CACHE_TTL_MS || 30 * 1000)
+        );
+      }
+    }
+
+    if(userMutado) {
       try {
-      const userMutado = await mutados.findOne({userLid: sender, grupo: from});
       //apaga todas as msg
       await sock.sendMessage(userMutado.grupo, {delete: msg.key})
       
-      const muteTentativa = await mutados.findOneAndUpdate({userLid: sender, grupo: from}, {$inc: {tentativasMsg: 1}}, {new: true});
+      const muteTentativa = await trackMongo(mongoMetrics, "mutados.findOneAndUpdate:tentativas", () =>
+        mutados.findOneAndUpdate({userLid: sender, grupo: from}, {$inc: {tentativasMsg: 1}}, {new: true}).lean()
+      );
       //se a pessoa for desmutada antes
-      if(!muteTentativa) return;
+      if(!muteTentativa) {
+        invalidateMute(sender, from);
+        return;
+      }
+      setMuteCache(sender, from, muteTentativa);
       //se ela tentar mandar mais de 3 mensagens
       if(muteTentativa.tentativasMsg >= 3) {
         //remove ela do grupo
         await sock.groupParticipantsUpdate(muteTentativa.grupo, [muteTentativa.userLid], 'remove');
         //apaga ela da colessao
-        await mutados.deleteOne({userLid: sender, grupo: from});
+        await trackMongo(mongoMetrics, "mutados.deleteOne:limite", () =>
+          mutados.deleteOne({userLid: sender, grupo: from})
+        );
+        invalidateMute(sender, from);
         
       }
       
@@ -692,18 +842,8 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     }
     
     addXp(sender, 1, sock, from, msg);
+    markQueuedWrite(mongoMetrics);
 
-    const body = (msg.message?.conversation) ||
-    (msg.message?.extendedTextMessage?.text) ||
-    (msg.message?.imageMessage?.caption) ||
-    (msg.message?.documentMessage?.caption) || msg?.message?.buttonsResponseMessage?.selectedButtonId || "Msg estranha...";
-    
-    const bodyCase = body.toLowerCase();
-    
-    //argumentos 
-    const args = body.slice(prefixo.length).trim().split(/ +/);
-    
-        
     //Caso tenha um aluguel a pagar
     const alugarExiste = await safeRedis(() => clientRedis.exists(`aluguel:${sender}&${from}`), 0);
     
@@ -774,28 +914,38 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       
       if(bodyCase.includes("aceitar")) {
         try {
+          const valorAposta = Number(apostaObject.valor) || 0;
           
           const msgEspera = await sock.sendMessage(from, {text: "Apostando cara ou coroa... Vamos ver quem vai ganhar"}, {quoted: msg});
           
           const caraOuCora = Math.floor(Math.random() * 100);
           
           if(caraOuCora < 50) {
-            await sock.sendMessage(from, {text: `Coroa! @${apostaObject.alvo.split("@")[0]} ganhou +${apostaObject.valor}`, mentions: [apostaObject.alvo], edit: msgEspera.key});
+            await sock.sendMessage(from, {text: `Coroa! @${apostaObject.alvo.split("@")[0]} ganhou +${valorAposta}`, mentions: [apostaObject.alvo], edit: msgEspera.key});
             //dá o dinheiro
-            await users.updateOne({userLid: apostaObject.alvo}, {$inc: {dinheiro: apostaObject.valor}});
-            //remove de quem perdeu
-            await users.updateOne({userLid: apostaObject.autor}, {$inc: {dinheiro: -apostaObject.valor}})
+            await Promise.all([
+              trackMongo(mongoMetrics, "users.findOneAndUpdate:apostaWinner", () =>
+                updateUserAndCache(apostaObject.alvo, {$inc: {dinheiro: valorAposta}}, {upsert: true})
+              ),
+              trackMongo(mongoMetrics, "users.findOneAndUpdate:apostaLoser", () =>
+                updateUserAndCache(apostaObject.autor, {$inc: {dinheiro: -valorAposta}}, {upsert: true})
+              )
+            ]);
             
             //apaga
             await safeRedis(() => clientRedis.del(`aposta:${sender}`));
           }
           else {
-            await sock.sendMessage(from, {text: `Cara! @${apostaObject.autor.split("@")[0]} ganhou +${apostaObject.valor}`, mentions: [apostaObject.autor], edit: msgEspera.key});
+            await sock.sendMessage(from, {text: `Cara! @${apostaObject.autor.split("@")[0]} ganhou +${valorAposta}`, mentions: [apostaObject.autor], edit: msgEspera.key});
             //dá o valor
-            await users.updateOne({userLid: apostaObject.autor}, {$inc: {dinheiro: apostaObject.valor}});
-            
-            //remove de quem perdeu
-            await users.updateOne({userLid: apostaObject.alvo}, {$inc: {dinheiro: -apostaObject.valor}})
+            await Promise.all([
+              trackMongo(mongoMetrics, "users.findOneAndUpdate:apostaWinner", () =>
+                updateUserAndCache(apostaObject.autor, {$inc: {dinheiro: valorAposta}}, {upsert: true})
+              ),
+              trackMongo(mongoMetrics, "users.findOneAndUpdate:apostaLoser", () =>
+                updateUserAndCache(apostaObject.alvo, {$inc: {dinheiro: -valorAposta}}, {upsert: true})
+              )
+            ]);
             
             await safeRedis(() => clientRedis.del(`aposta:${sender}`));
           }
@@ -807,7 +957,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
         
       }
       if(bodyCase.includes("recusar")) {
-        await sock.sendMessage(from, {text: `Aposta de: @${apostaObject.autor.split("@")[0]} recusada!`, mentions: [apostaObject.autot]}, {quoted: msg});
+        await sock.sendMessage(from, {text: `Aposta de: @${apostaObject.autor.split("@")[0]} recusada!`, mentions: [apostaObject.autor]}, {quoted: msg});
       }
       
       await safeRedis(() => clientRedis.del(`aposta:${sender}`))
@@ -822,9 +972,14 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
     if(bodyCase === "aceitar") {
       //Adiciona ao pedidor
-      await users.updateOne({userLid: namoroObject?.autor}, {$set: {"casal.parceiro": namoroObject.alvo, "casal.pedido": new Date()}});
-      //adiciona ao alvo 
-      await users.updateOne({userLid: sender}, {$set: {"casal.parceiro": namoroObject.autor, "casal.pedido": new Date()}});
+      await Promise.all([
+        trackMongo(mongoMetrics, "users.findOneAndUpdate:namoroAutor", () =>
+          updateUserAndCache(namoroObject?.autor, {$set: {"casal.parceiro": namoroObject.alvo, "casal.pedido": new Date()}}, {upsert: true})
+        ),
+        trackMongo(mongoMetrics, "users.findOneAndUpdate:namoroAlvo", () =>
+          updateUserAndCache(sender, {$set: {"casal.parceiro": namoroObject.autor, "casal.pedido": new Date()}}, {upsert: true})
+        )
+      ]);
       
       //deleta o pedido dos pendentes 
       await safeRedis(() => clientRedis.del(`namoro:${sender}`));
@@ -844,7 +999,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
   
   //pega os dados do grupo
-  const groupReply = await grupos.findOne({groupId: from});
+  const groupReply = groupDBInfo;
   
   //Caso o grupo tenha a anttotag ativa
   if(from.endsWith("@g.us") && groupReply?.antiTotag) {
@@ -882,10 +1037,13 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
     await sock.sendMessage(from, {delete: msg.key});
     
-    await advertidos.updateOne({grupo: from, userLid: sender}, {$inc: {adv: 1}}, {upsert: true});
-    
-    
-    let advs = await advertidos.findOne({userLid: sender, grupo: from});
+    let advs = await trackMongo(mongoMetrics, "advertidos.findOneAndUpdate:antlink", () =>
+      advertidos.findOneAndUpdate(
+        {grupo: from, userLid: sender},
+        {$inc: {adv: 1}},
+        {upsert: true, new: true}
+      ).lean()
+    );
     
     if(advs.adv >= 3) {
       await bot.reply(from, "Você teve 3 chances.");
@@ -920,7 +1078,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
 
   
       //Caso um grupo tenha auto download
-  const groupDonwload = await grupos.findOne({groupId: from});
+  const groupDonwload = groupDBInfo;
   
   if((groupDonwload && groupDonwload.autoDownload) || from.endsWith("@lid")) {
   if(body.includes("https://open.spotify.com/track/")) {
@@ -954,19 +1112,17 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       }
     
     //Caso o users tenha o modo sem prefixo
-if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
+if(noPrefixCommandCandidate && !isPrefixCommand) {
+  const noPrefixUser = await getUsersSender();
+
+  if(!noPrefixUser?.prefixo) {
   
-  const argsNoPrefix = body.trim().split(" ");
+  const argsNoPrefix = body.trim().split(/ +/);
   
   const commandNamePrefix = argsNoPrefix.shift().toLowerCase();
   
   //Busca pelo mapa
-  const commandNoPrefix = commandsMap.get(commandNamePrefix);
-  
-  
-  
-  //se existir
-  if(commandNoPrefix) {
+  const commandNoPrefix = noPrefixCommandCandidate;
   
       //Verifica se tem spam no comando
     if(spamCommand(sender, commandNamePrefix)) {
@@ -984,14 +1140,14 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
             //lida com aluguel
     const isPadrao = commandNoPrefix.categoria === "padrao";
     if(!isPadrao && from.endsWith("@g.us")) {
-    const grupoAluguel = await grupos.findOne({groupId: from});
+    const grupoAluguel = groupDBInfo;
     
     if(!grupoAluguel) return;
     const dataAtual = Date.now();
     
-    const isDono = !!doninhos;
+    const isDono = await getOwner();
     
-    const vipExpireAt = usersSender?.vencimentoVip?.getTime?.();
+    const vipExpireAt = noPrefixUser?.vencimentoVip?.getTime?.();
     
     const hasVipAtivo = Number.isFinite(vipExpireAt) && dataAtual <= vipExpireAt;
     
@@ -1003,7 +1159,9 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
     }
     }
     
-  commandNoPrefix.execute(sock, msg, from, argsNoPrefix, erros_prontos, espera_pronta, bot, sender);
+  await commandNoPrefix.execute(sock, msg, from, argsNoPrefix, erros_prontos, espera_pronta, bot, sender);
+  queueCommandActivity(sender, from);
+  markQueuedWrite(mongoMetrics, 3);
   
   //Adiciona nas metricas
   await safeRedis(() => clientRedis.incr("metrics:commands:min"));
@@ -1043,9 +1201,6 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
   }
 
 
-
-
-  let userFind = await users.findOne({userLid: sender});
 
 
 //tratamento dos comandos
@@ -1108,7 +1263,7 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
     }
     
     //busca um grupo
-    const grupoFun = await grupos.findOne({groupId: from});
+    const grupoFun = groupDBInfo;
     
     //se um comando for de diversao
     if (commandGet.categoria && commandGet.categoria === "diversao") {
@@ -1129,16 +1284,17 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
     }
     
               //lida com aluguel
+    const commandUser = await getUsersSender();
     const isPadrao = commandGet.categoria === "padrao";
     if(!isPadrao && from.endsWith("@g.us") && process.env.DEV_AMBIENT === "false") {
-    const grupoAluguel = await grupos.findOne({groupId: from});
+    const grupoAluguel = groupDBInfo;
     
     if(!grupoAluguel) return;
     const dataAtual = Date.now();
     
-    const isDono = !!doninhos;
+    const isDono = await getOwner();
     
-    const vipExpireAt = usersSender?.vencimentoVip?.getTime?.();
+    const vipExpireAt = commandUser?.vencimentoVip?.getTime?.();
     
     const hasVipAtivo = Number.isFinite(vipExpireAt) && dataAtual <= vipExpireAt;
     
@@ -1160,14 +1316,8 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
     //pausa a simulacao
     await sock.sendPresenceUpdate('paused', from);
 //adiciona no contador de comandos
-    await rankativos.updateOne({userLid: sender, from: from}, {$inc: {cmdUsados: 1}}, {upsert: true})
-//adiciona no contador do grupo
-   if(from.endsWith("@g.us")) {
-   await grupos.updateOne({groupId: from}, {$inc: {cmdUsados: 1}});
-     
-   }
-//adiciona no contador de user
-   await users.updateOne({userLid: sender}, {$inc: {cmdCount: 1}});
+    queueCommandActivity(sender, from);
+    markQueuedWrite(mongoMetrics, 3);
    
      //Adiciona nas metricas
   await safeRedis(() => clientRedis.incr("metrics:commands:min"));
@@ -1179,8 +1329,11 @@ if(!usersSender?.prefixo && !body.startsWith(prefixo)) {
     processMessage(grupoRemote);
     
     
-
-
+    } catch (err) {
+      console.error("[messages] erro ao processar mensagem:", err);
+    } finally {
+      finishMessageMongoMetrics(mongoMetrics);
+    }
   });
 
 

--- a/src/events/participantUp.js
+++ b/src/events/participantUp.js
@@ -1,4 +1,4 @@
-const { grupos } = require("../database/models/grupos");
+const { ensureGroup } = require("../utils/dbHelpers");
 
 
 
@@ -14,7 +14,7 @@ module.exports = (sock) => {
     
     const metadata = await sock.groupMetadata(from);
     
-    const groupsDb = await grupos.findOne({groupId: from});
+    const groupsDb = await ensureGroup(from, metadata);
     
     if (groupsDb?.configs?.welcome) {
       const action = update.action

--- a/src/lib/mongoDB.js
+++ b/src/lib/mongoDB.js
@@ -1,44 +1,58 @@
-/*
-  DECIDIMOS FAZER ESSA GAMBIARRA PARA CONECTAR AO MONGO, POIS O MONGODB SE DESCONECTA DE VEZ EM QUANDO, ENTÃO PARA EVITAR QUE O SERVIDOR FIQUE CAINDO, DECIDIMOS COLOCAR UM SETTIMEOUT PARA REINICIAR O SERVIDOR CASO O MONGO DESCONECTE, E TAMBÉM COLOCAMOS UM LOG PARA SABER QUANDO O MONGO DESCONECTA E QUANDO ELE RECONECTA. 
-  NO ENTANTO, ESSA NÃO É A MELHOR SOLUÇÃO, POIS O SERVIDOR FICA REINICIANDO SEM NECESSIDADE, O IDEAL SERIA OTIMIZAR AS QUANTIDADE DE QUERY MAS  O TEMPO ESTÁ APERTADO E ESSA SOLUÇÃO FUNCIONA, ENTÃO DECIDIMOS DEIXAR ASSIM POR ENQUANTO, MAS FUTURAMENTE VAMOS OTIMIZAR ISSO PARA EVITAR QUE O SERVIDOR FIQUE REINICIANDO SEM NECESSIDADE.
-*/
-
-
-
-
 const mongoose = require("mongoose");
 
+let connectPromise = null;
+let eventsRegistered = false;
 
-async function connectDB() {
-    try {
-  await mongoose.connect(process.env.URIDB);
-  console.log("mongoDB Conectado!"); 
+function registerMongoEvents() {
+  if (eventsRegistered) return;
+  eventsRegistered = true;
 
-} 
+  mongoose.connection.on("connected", () => {
+    console.log("[mongo] conectado");
+  });
 
-  catch (error) { 
+  mongoose.connection.on("disconnected", () => {
+    console.error("[mongo] desconectado; o driver vai tentar reconectar pelo pool");
+  });
 
-    console.error("erro ao conectaar", error);
+  mongoose.connection.on("reconnected", () => {
+    console.log("[mongo] reconectado");
+  });
 
-    setTimeout(() => {      process.exit(1);
-    }, 5000);
-    
-    }
+  mongoose.connection.on("error", (err) => {
+    console.error("[mongo] erro na conexao:", err);
+  });
 }
 
-mongoose.connection.on("disconnected", () => {
-  console.log("MongoDB desconectado!");
-  setTimeout(() => {    process.exit(1);
-  }, 5000);
+async function connectDB() {
+  registerMongoEvents();
 
-});
+  if (mongoose.connection.readyState === 1) {
+    return mongoose.connection;
+  }
 
-mongoose.connection.on("reconnected", () => {
-  console.log("MongoDB reconectado!");
-});
+  if (connectPromise) {
+    return connectPromise;
+  }
 
-mongoose.connection.on("error", (err) => {
-  console.error("Erro na conexão Mongo:", err);
-});
+  connectPromise = mongoose
+    .connect(process.env.URIDB, {
+      maxPoolSize: Number(process.env.MONGO_MAX_POOL_SIZE || 20),
+      minPoolSize: Number(process.env.MONGO_MIN_POOL_SIZE || 2),
+      serverSelectionTimeoutMS: Number(process.env.MONGO_SERVER_SELECTION_TIMEOUT_MS || 10000),
+      socketTimeoutMS: Number(process.env.MONGO_SOCKET_TIMEOUT_MS || 45000)
+    })
+    .then(() => {
+      console.log("mongoDB Conectado!");
+      connectPromise = null;
+      return mongoose.connection;
+    })
+    .catch((err) => {
+      connectPromise = null;
+      throw err;
+    });
 
-module.exports = connectDB
+  return connectPromise;
+}
+
+module.exports = connectDB;

--- a/src/utils/dbHelpers.js
+++ b/src/utils/dbHelpers.js
@@ -1,0 +1,201 @@
+const { users } = require("../database/models/users");
+const { grupos } = require("../database/models/grupos");
+const { donos } = require("../database/models/donos");
+const { groupCache, muteCache, ownerCache, userCache } = require("./hotPathCache");
+const NULL_CACHE_TTL_MS = Number(process.env.NULL_CACHE_TTL_MS || 5 * 1000);
+
+function toPlain(doc) {
+  if (!doc) return null;
+  if (typeof doc.toObject === "function") return doc.toObject();
+  return doc;
+}
+
+function invalidateUser(userLid) {
+  if (userLid) userCache.delete(userLid);
+}
+
+function invalidateGroup(groupId) {
+  if (groupId) groupCache.delete(groupId);
+}
+
+function invalidateOwner(userLid) {
+  if (userLid) ownerCache.delete(userLid);
+}
+
+function muteCacheKey(userLid, groupId) {
+  return `${groupId || ""}\u0000${userLid || ""}`;
+}
+
+function setMuteCache(userLid, groupId, value, ttlMs) {
+  if (!userLid || !groupId) return;
+  muteCache.set(muteCacheKey(userLid, groupId), value, ttlMs);
+}
+
+function invalidateMute(userLid, groupId) {
+  if (!userLid || !groupId) return;
+  muteCache.delete(muteCacheKey(userLid, groupId));
+}
+
+async function ensureUser(userLid, name = "Sem nome") {
+  if (!userLid) return null;
+
+  const cached = userCache.get(userLid);
+  if (cached) return cached;
+
+  const user = await users.findOneAndUpdate(
+    { userLid },
+    { $setOnInsert: { userLid, name } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  userCache.set(userLid, toPlain(user));
+  return user;
+}
+
+async function getUserCached(userLid) {
+  if (!userLid) return null;
+
+  const cached = userCache.get(userLid);
+  if (cached !== undefined) return cached;
+
+  const user = await users.findOne({ userLid }).lean();
+  userCache.set(userLid, user || null, user ? undefined : NULL_CACHE_TTL_MS);
+  return user;
+}
+
+function groupDefaults(groupId, metadata = {}) {
+  return {
+    groupId,
+    grupoName: metadata.subject || metadata.grupoName || "Sem nome",
+    ownerId: metadata.owner || metadata.ownerId || "Sem dono"
+  };
+}
+
+function normalizeUpdateWithInsertDefaults(groupId, update, metadata) {
+  const hasOperator = Object.keys(update).some((key) => key.startsWith("$"));
+  const normalized = hasOperator ? { ...update } : { $set: update };
+
+  normalized.$setOnInsert = {
+    ...groupDefaults(groupId, metadata),
+    ...(normalized.$setOnInsert || {})
+  };
+
+  return normalized;
+}
+
+async function ensureGroup(groupId, metadata = {}) {
+  if (!groupId) return null;
+
+  const cached = groupCache.get(groupId);
+  if (cached) return cached;
+
+  const group = await grupos.findOneAndUpdate(
+    { groupId },
+    { $setOnInsert: groupDefaults(groupId, metadata) },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
+
+  groupCache.set(groupId, toPlain(group));
+  return group;
+}
+
+async function ensureGroupFromSocket(sock, groupId) {
+  const cached = groupCache.get(groupId);
+  if (cached) return cached;
+
+  let metadata = {};
+
+  try {
+    metadata = await sock.groupMetadata(groupId);
+  } catch (err) {
+    console.error("Erro ao buscar metadata do grupo:", err?.data || err?.message || err);
+  }
+
+  return ensureGroup(groupId, metadata);
+}
+
+async function updateGroupAndCache(groupId, update, options = {}) {
+  if (!groupId) return null;
+
+  const group = await grupos.findOneAndUpdate(
+    { groupId },
+    normalizeUpdateWithInsertDefaults(groupId, update, options.metadata),
+    { upsert: options.upsert !== false, new: true, setDefaultsOnInsert: true }
+  );
+
+  groupCache.set(groupId, toPlain(group));
+  return group;
+}
+
+async function updateUserAndCache(userLid, update, options = {}) {
+  if (!userLid) return null;
+
+  const hasOperator = Object.keys(update).some((key) => key.startsWith("$"));
+  const normalized = hasOperator ? { ...update } : { $set: update };
+
+  if (options.upsert === true) {
+    normalized.$setOnInsert = {
+      userLid,
+      name: options.name || "Sem nome",
+      ...(normalized.$setOnInsert || {})
+    };
+  }
+
+  const user = await users.findOneAndUpdate(
+    { userLid, ...(options.filter || {}) },
+    normalized,
+    { upsert: options.upsert === true, new: true, setDefaultsOnInsert: true }
+  );
+
+  if (user) userCache.set(userLid, toPlain(user));
+  else invalidateUser(userLid);
+  return user;
+}
+
+async function isOwnerCached(userLid) {
+  if (!userLid) return false;
+
+  const cached = ownerCache.get(userLid);
+  if (cached !== undefined) return cached;
+
+  const owner = await donos.findOne({ userLid }).lean();
+  const isOwner = !!owner;
+  ownerCache.set(userLid, isOwner, isOwner ? undefined : 60 * 1000);
+  return isOwner;
+}
+
+async function getGroupPermission(sock, groupId, sender) {
+  const [metadata, isOwner] = await Promise.all([
+    sock.groupMetadata(groupId),
+    isOwnerCached(sender)
+  ]);
+
+  const adminIds = metadata.participants
+    .filter((participant) => participant.admin)
+    .flatMap((participant) => [participant.id, participant.lid])
+    .filter(Boolean);
+
+  return {
+    metadata,
+    isOwner,
+    isAdmin: adminIds.includes(sender),
+    allowed: isOwner || adminIds.includes(sender)
+  };
+}
+
+module.exports = {
+  ensureGroup,
+  ensureGroupFromSocket,
+  ensureUser,
+  getGroupPermission,
+  getUserCached,
+  invalidateGroup,
+  invalidateMute,
+  invalidateOwner,
+  invalidateUser,
+  isOwnerCached,
+  muteCacheKey,
+  setMuteCache,
+  updateGroupAndCache,
+  updateUserAndCache
+};

--- a/src/utils/hotPathCache.js
+++ b/src/utils/hotPathCache.js
@@ -1,0 +1,104 @@
+class TtlCache {
+  constructor(name, ttlMs, maxSize = 1000) {
+    this.name = name;
+    this.ttlMs = ttlMs;
+    this.maxSize = maxSize;
+    this.store = new Map();
+    this.stats = {
+      hits: 0,
+      misses: 0,
+      sets: 0,
+      deletes: 0,
+      evictions: 0
+    };
+  }
+
+  get(key) {
+    const entry = this.store.get(key);
+
+    if (!entry) {
+      this.stats.misses += 1;
+      logCacheEvent(this.name, "miss", key);
+      return undefined;
+    }
+
+    if (entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      this.stats.misses += 1;
+      this.stats.evictions += 1;
+      logCacheEvent(this.name, "expired", key);
+      return undefined;
+    }
+
+    this.stats.hits += 1;
+    logCacheEvent(this.name, "hit", key);
+    return entry.value;
+  }
+
+  set(key, value, ttlMs = this.ttlMs) {
+    if (!this.store.has(key) && this.store.size >= this.maxSize) {
+      const oldestKey = this.store.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.store.delete(oldestKey);
+        this.stats.evictions += 1;
+      }
+    }
+
+    this.store.set(key, {
+      value,
+      expiresAt: Date.now() + ttlMs
+    });
+    this.stats.sets += 1;
+  }
+
+  delete(key) {
+    const deleted = this.store.delete(key);
+    if (deleted) this.stats.deletes += 1;
+    return deleted;
+  }
+
+  snapshot() {
+    return {
+      name: this.name,
+      size: this.store.size,
+      ...this.stats
+    };
+  }
+}
+
+function logCacheEvent(name, type, key) {
+  if (process.env.DEBUG_MONGO_CACHE !== "true") return;
+  console.log(`[mongo-cache] ${name} ${type}: ${key}`);
+}
+
+const userCache = new TtlCache("user", Number(process.env.USER_CACHE_TTL_MS || 60 * 1000), 5000);
+const groupCache = new TtlCache("group", Number(process.env.GROUP_CACHE_TTL_MS || 30 * 1000), 2000);
+const ownerCache = new TtlCache("owner", Number(process.env.OWNER_CACHE_TTL_MS || 10 * 60 * 1000), 2000);
+const muteCache = new TtlCache("mute", Number(process.env.MUTE_CACHE_TTL_MS || 10 * 60 * 1000), 5000);
+const caches = [userCache, groupCache, ownerCache, muteCache];
+
+const summaryMs = Number(process.env.MONGO_CACHE_SUMMARY_MS || 60 * 1000);
+if (summaryMs > 0) {
+  const summaryTimer = setInterval(() => {
+    const summary = caches
+      .map((cache) => {
+        const snapshot = cache.snapshot();
+        return `${snapshot.name}:size=${snapshot.size},hit=${snapshot.hits},miss=${snapshot.misses}`;
+      })
+      .join(" | ");
+
+    console.log(`[mongo-cache] resumo ${summary}`);
+  }, summaryMs);
+
+  if (typeof summaryTimer.unref === "function") {
+    summaryTimer.unref();
+  }
+}
+
+module.exports = {
+  TtlCache,
+  groupCache,
+  muteCache,
+  ownerCache,
+  userCache
+};

--- a/src/utils/instagram.js
+++ b/src/utils/instagram.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
-const { users } = require("../database/models/users");
 const { normalizeUserLid } = require("./normalizeUserLid");
+const { updateUserAndCache } = require("./dbHelpers");
 
 async function instaDl(sock, msg, from, body, erros_prontos, espera_pronta) {
   
@@ -26,7 +26,7 @@ async function instaDl(sock, msg, from, body, erros_prontos, espera_pronta) {
       msg?.key?.remoteJid
     );
 
-    await users.updateOne({userLid: sender}, {$inc: {donwloads: 1}});
+    await updateUserAndCache(sender, {$inc: {donwloads: 1}});
     
     
     

--- a/src/utils/messageMongoMetrics.js
+++ b/src/utils/messageMongoMetrics.js
@@ -1,0 +1,91 @@
+const SLOW_QUERY_MS = Number(process.env.MONGO_HOTPATH_SLOW_MS || 150);
+const SUMMARY_INTERVAL_MS = Number(process.env.MONGO_HOTPATH_SUMMARY_MS || 60 * 1000);
+
+const totals = {
+  messages: 0,
+  queries: 0,
+  queryMs: 0,
+  queuedWrites: 0,
+  slowQueries: 0,
+  lastSummaryAt: Date.now()
+};
+
+function createMessageMongoMetrics({ from, sender }) {
+  const startedAt = Date.now();
+
+  return {
+    from,
+    sender,
+    queries: 0,
+    queryMs: 0,
+    queuedWrites: 0,
+    slowQueries: []
+  };
+}
+
+async function trackMongo(metrics, label, operation) {
+  const startedAt = Date.now();
+
+  try {
+    return await operation();
+  } finally {
+    const duration = Date.now() - startedAt;
+
+    metrics.queries += 1;
+    metrics.queryMs += duration;
+    totals.queries += 1;
+    totals.queryMs += duration;
+
+    if (duration >= SLOW_QUERY_MS) {
+      metrics.slowQueries.push({ label, duration });
+      totals.slowQueries += 1;
+      console.log(`[mongo-hotpath] query lenta ${label}: ${duration}ms`);
+    }
+  }
+}
+
+function markQueuedWrite(metrics, count = 1) {
+  metrics.queuedWrites += count;
+  totals.queuedWrites += count;
+}
+
+function finishMessageMongoMetrics(metrics) {
+  totals.messages += 1;
+
+  if (
+    process.env.DEBUG_MONGO_HOTPATH === "true" ||
+    metrics.queries >= Number(process.env.MONGO_HOTPATH_WARN_QUERIES || 6)
+  ) {
+    console.log(
+      `[mongo-hotpath] msg from=${metrics.from} sender=${metrics.sender} ` +
+      `queries=${metrics.queries} queuedWrites=${metrics.queuedWrites} queryMs=${metrics.queryMs}`
+    );
+  }
+
+  const now = Date.now();
+  if (now - totals.lastSummaryAt >= SUMMARY_INTERVAL_MS) {
+    const avgQueries = totals.messages ? (totals.queries / totals.messages).toFixed(2) : "0.00";
+    const avgQueryMs = totals.queries ? (totals.queryMs / totals.queries).toFixed(1) : "0.0";
+    const avgQueuedWrites = totals.messages ? (totals.queuedWrites / totals.messages).toFixed(2) : "0.00";
+
+    console.log(
+      `[mongo-hotpath] resumo ${totals.messages} msgs: ` +
+      `avgQueries=${avgQueries}, avgQueryMs=${avgQueryMs}, ` +
+      `avgQueuedWrites=${avgQueuedWrites}, slowQueries=${totals.slowQueries}`
+    );
+
+    totals.messages = 0;
+    totals.queries = 0;
+    totals.queryMs = 0;
+    totals.queuedWrites = 0;
+    totals.slowQueries = 0;
+    totals.lastSummaryAt = now;
+  }
+}
+
+module.exports = {
+  createMessageMongoMetrics,
+  finishMessageMongoMetrics,
+  markQueuedWrite,
+  trackMongo
+};

--- a/src/utils/statsBatcher.js
+++ b/src/utils/statsBatcher.js
@@ -1,0 +1,178 @@
+const { rankativos } = require("../database/models/rankativos");
+const { grupos } = require("../database/models/grupos");
+const { users } = require("../database/models/users");
+const { groupCache, userCache } = require("./hotPathCache");
+
+const FLUSH_INTERVAL_MS = Number(process.env.STATS_FLUSH_INTERVAL_MS || 5000);
+const MAX_PENDING_KEYS = Number(process.env.STATS_FLUSH_MAX_PENDING_KEYS || 200);
+
+const rankIncrements = new Map();
+const groupCommandIncrements = new Map();
+const userCommandIncrements = new Map();
+
+let flushTimer = null;
+let flushing = false;
+
+function rankKey(userLid, from) {
+  return `${userLid}\u0000${from}`;
+}
+
+function queueRankIncrement(userLid, from, field, amount = 1) {
+  if (!userLid || !from) return;
+
+  const key = rankKey(userLid, from);
+  const current = rankIncrements.get(key) || {
+    userLid,
+    from,
+    msg: 0,
+    cmdUsados: 0
+  };
+
+  current[field] += amount;
+  rankIncrements.set(key, current);
+  scheduleFlush();
+}
+
+function queueMessageActivity(userLid, from, amount = 1) {
+  queueRankIncrement(userLid, from, "msg", amount);
+}
+
+function queueCommandActivity(userLid, from, amount = 1) {
+  queueRankIncrement(userLid, from, "cmdUsados", amount);
+
+  if (from?.endsWith("@g.us")) {
+    groupCommandIncrements.set(from, (groupCommandIncrements.get(from) || 0) + amount);
+  }
+
+  if (userLid) {
+    userCommandIncrements.set(userLid, (userCommandIncrements.get(userLid) || 0) + amount);
+  }
+
+  scheduleFlush();
+}
+
+function pendingKeyCount() {
+  return rankIncrements.size + groupCommandIncrements.size + userCommandIncrements.size;
+}
+
+function scheduleFlush() {
+  if (pendingKeyCount() >= MAX_PENDING_KEYS) {
+    setImmediate(() => flushStats("max-pending"));
+    return;
+  }
+
+  if (flushTimer) return;
+
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    flushStats("interval");
+  }, FLUSH_INTERVAL_MS);
+
+  if (typeof flushTimer.unref === "function") {
+    flushTimer.unref();
+  }
+}
+
+async function flushStats(reason = "manual") {
+  if (flushing) return;
+  if (pendingKeyCount() === 0) return;
+
+  flushing = true;
+
+  const rankSnapshot = Array.from(rankIncrements.values());
+  const groupSnapshot = Array.from(groupCommandIncrements.entries());
+  const userSnapshot = Array.from(userCommandIncrements.entries());
+
+  rankIncrements.clear();
+  groupCommandIncrements.clear();
+  userCommandIncrements.clear();
+
+  const startedAt = Date.now();
+
+  try {
+    const rankOps = rankSnapshot.map((item) => {
+      const inc = {};
+      if (item.msg) inc.msg = item.msg;
+      if (item.cmdUsados) inc.cmdUsados = item.cmdUsados;
+
+      return {
+        updateOne: {
+          filter: { userLid: item.userLid, from: item.from },
+          update: { $inc: inc },
+          upsert: true
+        }
+      };
+    });
+
+    const groupOps = groupSnapshot.map(([groupId, amount]) => ({
+      updateOne: {
+        filter: { groupId },
+        update: { $inc: { cmdUsados: amount } }
+      }
+    }));
+
+    const userOps = userSnapshot.map(([userLid, amount]) => ({
+      updateOne: {
+        filter: { userLid },
+        update: { $inc: { cmdCount: amount } }
+      }
+    }));
+
+    await Promise.all([
+      rankOps.length ? rankativos.bulkWrite(rankOps, { ordered: false }) : null,
+      groupOps.length ? grupos.bulkWrite(groupOps, { ordered: false }) : null,
+      userOps.length ? users.bulkWrite(userOps, { ordered: false }) : null
+    ]);
+
+    for (const [groupId] of groupSnapshot) groupCache.delete(groupId);
+    for (const [userLid] of userSnapshot) userCache.delete(userLid);
+
+    console.log(
+      `[mongo-stats] flush ${reason}: rank=${rankOps.length}, group=${groupOps.length}, ` +
+      `user=${userOps.length}, ms=${Date.now() - startedAt}`
+    );
+  } catch (err) {
+    console.error("[mongo-stats] erro ao gravar contadores em lote:", err);
+
+    for (const item of rankSnapshot) {
+      const key = rankKey(item.userLid, item.from);
+      const current = rankIncrements.get(key) || {
+        userLid: item.userLid,
+        from: item.from,
+        msg: 0,
+        cmdUsados: 0
+      };
+      current.msg += item.msg;
+      current.cmdUsados += item.cmdUsados;
+      rankIncrements.set(key, current);
+    }
+
+    for (const [groupId, amount] of groupSnapshot) {
+      groupCommandIncrements.set(groupId, (groupCommandIncrements.get(groupId) || 0) + amount);
+    }
+
+    for (const [userLid, amount] of userSnapshot) {
+      userCommandIncrements.set(userLid, (userCommandIncrements.get(userLid) || 0) + amount);
+    }
+  } finally {
+    flushing = false;
+
+    if (pendingKeyCount() > 0) {
+      scheduleFlush();
+    }
+  }
+}
+
+process.once("beforeExit", () => {
+  if (pendingKeyCount() > 0) {
+    flushStats("beforeExit").catch((err) => {
+      console.error("[mongo-stats] erro no flush final:", err);
+    });
+  }
+});
+
+module.exports = {
+  flushStats,
+  queueCommandActivity,
+  queueMessageActivity
+};

--- a/src/utils/tiktok.js
+++ b/src/utils/tiktok.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
-const { users } = require("../database/models/users");
 const { normalizeUserLid } = require("./normalizeUserLid");
+const { ensureUser, updateUserAndCache } = require("./dbHelpers");
 const { ensureTikTokApiRunning } = require("./tiktokApiRuntime");
 
 const tiktokApi = axios.create({
@@ -411,7 +411,8 @@ async function countDownload(sender) {
   const userLid = normalizeUserLid(sender);
   if (!userLid) return;
   try {
-    await users.updateOne({ userLid }, { $inc: { donwloads: 1 } }, { upsert: true });
+    await ensureUser(userLid, "Sem nome");
+    await updateUserAndCache(userLid, { $inc: { donwloads: 1 } });
   } catch (err) {
     console.error("Falha ao atualizar contador de downloads:", err);
   }

--- a/src/utils/xp.js
+++ b/src/utils/xp.js
@@ -1,49 +1,194 @@
 const { users } = require("../database/models/users.js");
+const { userCache } = require("./hotPathCache");
 
-async function addXp(user, quantidade, sock, from, msg) {
-  try {
-    
-    const userFind = await users.findOneAndUpdate({userLid: user}, {$inc: {xp: quantidade}}, {upsert: true, new: true});
-    
-    //const proximoNivel = (userFind?.proximolevel || 100) + 100;
-    
-    if(userFind?.xp > userFind.proximolevel) {
-      
-      await sock.sendMessage(from, {text: "Up!"}, {quoted: msg});
-      
-      const level = await users.findOneAndUpdate({userLid: user}, {$inc: {level: 1, proximolevel: 100}}, {upsert: true, new: true});
-      
-      let senderProfile;
-      
-      try {
-        senderProfile = await sock.profilePictureUrl(user, 'image');
-      }
-      catch(err) {
-        senderProfile = "https://files.catbox.moe/0ug48m";
-      }
-      
-      const pushname = msg?.pushName || "Sem nome"
-      
-      const imageXp = `https://zero-two-apis.com.br/api/canvas/levelup2?foto=${encodeURIComponent("https://files.catbox.moe/0ug48m")}&nome=${encodeURIComponent(pushname)}&lvb=${userFind?.level}&lva=${level?.level}&fundo=https://files.catbox.moe/b05qkn`
-      
-      console.log(imageXp)
-      
-      const button = [
-        {buttonId: `${process.env.PREFIXO}perfil`, buttonText: {displayText: "𝐕𝐞𝐫 𝐏𝐞𝐫𝐟𝐢𝐥 ✨"}, type: 1}
-        ];
-      
-      await sock.sendMessage(from, {image: {url: imageXp}, caption: `Parabéns ${pushname}🎉 Você acaba de subir de nível🔥`, buttons: button});
-      
-    }
-    
-    
-    
-    
-  }
-  catch(err) {
-    console.error(err);
-  }
-  
+const FLUSH_INTERVAL_MS = Number(process.env.XP_FLUSH_INTERVAL_MS || 5000);
+const pendingXp = new Map();
+
+let flushTimer = null;
+let flushing = false;
+
+function addXp(user, quantidade, sock, from, msg) {
+  if (!user || !quantidade) return;
+
+  const current = pendingXp.get(user) || {
+    quantidade: 0,
+    sock,
+    from,
+    msg
+  };
+
+  current.quantidade += quantidade;
+  current.sock = sock || current.sock;
+  current.from = from || current.from;
+  current.msg = msg || current.msg;
+
+  pendingXp.set(user, current);
+  scheduleFlush();
 }
+
+function scheduleFlush() {
+  if (flushTimer) return;
+
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    flushXp("interval");
+  }, FLUSH_INTERVAL_MS);
+
+  if (typeof flushTimer.unref === "function") {
+    flushTimer.unref();
+  }
+}
+
+async function flushXp(reason = "manual") {
+  if (flushing) return;
+  if (pendingXp.size === 0) return;
+
+  flushing = true;
+
+  const snapshot = Array.from(pendingXp.entries());
+  pendingXp.clear();
+
+  const startedAt = Date.now();
+
+  try {
+    await flushUsersXp(snapshot);
+
+    console.log(`[mongo-xp] flush ${reason}: users=${snapshot.length}, ms=${Date.now() - startedAt}`);
+  } catch (err) {
+    console.error("[mongo-xp] erro ao gravar xp em lote:", err);
+
+    if (!err.xpWriteDone) {
+      requeueSnapshot(snapshot);
+    } else {
+      console.error("[mongo-xp] xp ja gravado; nao reenfileirando para evitar duplicar pontos.");
+    }
+  } finally {
+    flushing = false;
+
+    if (pendingXp.size > 0) {
+      scheduleFlush();
+    }
+  }
+}
+
+function requeueSnapshot(snapshot) {
+  for (const [user, payload] of snapshot) {
+    const current = pendingXp.get(user) || {
+      quantidade: 0,
+      sock: payload.sock,
+      from: payload.from,
+      msg: payload.msg
+    };
+
+    current.quantidade += payload.quantidade;
+    current.sock = payload.sock || current.sock;
+    current.from = payload.from || current.from;
+    current.msg = payload.msg || current.msg;
+
+    pendingXp.set(user, current);
+  }
+}
+
+async function flushUsersXp(snapshot) {
+  if (!snapshot.length) return;
+
+  let xpWriteDone = false;
+  const payloadByUser = new Map(snapshot);
+
+  try {
+    await users.bulkWrite(
+      snapshot.map(([user, payload]) => ({
+        updateOne: {
+          filter: { userLid: user },
+          update: {
+            $inc: { xp: payload.quantidade },
+            $setOnInsert: { userLid: user, name: payload.msg?.pushName || "Sem nome" }
+          },
+          upsert: true
+        }
+      })),
+      { ordered: false }
+    );
+    xpWriteDone = true;
+
+    const docs = await users.find({ userLid: { $in: snapshot.map(([user]) => user) } }).lean();
+    const levelUps = [];
+
+    for (const doc of docs) {
+      userCache.set(doc.userLid, doc);
+
+      if (!doc?.xp || doc.xp <= doc.proximolevel) continue;
+
+      const levelsToAdd = Math.max(
+        1,
+        Math.floor((doc.xp - doc.proximolevel) / 100) + 1
+      );
+
+      levelUps.push({
+        doc,
+        levelsToAdd,
+        nextLevel: (doc.level || 0) + levelsToAdd,
+        nextProximoLevel: (doc.proximolevel || 100) + (100 * levelsToAdd)
+      });
+    }
+
+    if (levelUps.length) {
+      await users.bulkWrite(
+        levelUps.map(({ doc, levelsToAdd }) => ({
+          updateOne: {
+            filter: { userLid: doc.userLid },
+            update: { $inc: { level: levelsToAdd, proximolevel: 100 * levelsToAdd } }
+          }
+        })),
+        { ordered: false }
+      );
+    }
+
+    for (const levelUp of levelUps) {
+      const payload = payloadByUser.get(levelUp.doc.userLid);
+      if (!payload?.sock || !payload?.from) continue;
+
+      const cached = {
+        ...levelUp.doc,
+        level: levelUp.nextLevel,
+        proximolevel: levelUp.nextProximoLevel
+      };
+      userCache.set(levelUp.doc.userLid, cached);
+      try {
+        await sendLevelUp(levelUp, payload);
+      } catch (err) {
+        console.error("[mongo-xp] erro ao enviar aviso de level up:", err);
+      }
+    }
+  } catch (err) {
+    err.xpWriteDone = xpWriteDone;
+    throw err;
+  }
+}
+
+async function sendLevelUp(levelUp, payload) {
+  await payload.sock.sendMessage(payload.from, { text: "Up!" }, { quoted: payload.msg });
+
+  const pushname = payload.msg?.pushName || "Sem nome";
+  const imageXp = `https://zero-two-apis.com.br/api/canvas/levelup2?foto=${encodeURIComponent("https://files.catbox.moe/0ug48m")}&nome=${encodeURIComponent(pushname)}&expnow=${levelUp.doc?.xp}&expall=${levelUp.nextProximoLevel}&level=${levelUp.nextLevel}&fundo=https://files.catbox.moe/b05qkn`;
+
+  const button = [
+    { buttonId: `${process.env.PREFIXO}perfil`, buttonText: { displayText: "Ver Perfil ✨" }, type: 1 }
+  ];
+
+  await payload.sock.sendMessage(payload.from, {
+    image: { url: imageXp },
+    caption: `Parabéns ${pushname}🎉 Você acaba de subir de nível🔥`,
+    buttons: button
+  });
+}
+
+process.once("beforeExit", () => {
+  if (pendingXp.size > 0) {
+    flushXp("beforeExit").catch((err) => {
+      console.error("[mongo-xp] erro no flush final:", err);
+    });
+  }
+});
 
 module.exports = addXp;


### PR DESCRIPTION
## Resumo

Este PR troca a solução temporária de restart/reconnect do Mongo por uma otimização real no caminho quente da Yuki. A ideia principal é parar de consultar o MongoDB para cada mensagem recebida e concentrar leituras/escritas em cache, helpers compartilhados e batch writes.

Também foi integrado em cima do `origin/main` mais recente (`f10f5a2`), que já inclui os PRs de Catbox (#121, #122 e #123). Os arquivos e rotas de Catbox foram preservados.

## Causa raiz

O fluxo de mensagens fazia consultas no Mongo antes mesmo de saber se a mensagem precisava de comando:

- verificação de dono/usuário/grupo em toda mensagem;
- consultas repetidas de grupo e usuário dentro da mesma mensagem;
- checagem de mute por mensagem de grupo;
- updates de XP, rank, contador de comandos e stats no caminho quente;
- comandos repetindo `findOne`/`find` para user/grupo/dono que o dispatcher já tinha contexto para reaproveitar.

O PR #120 diminuiu pouco esse problema e ainda deixava riscos:

- cache Redis de dono incompleto, com comportamento errado quando havia cache;
- VIP no privado ficou comentado, mudando regra de acesso;
- `process.exit(1)` em falha/desconexão do Mongo mascara o problema e pode reiniciar em loop;
- não reduzia writes frequentes de XP/rank/stats.

## O que mudou

### Mongo/conexão

- `src/lib/mongoDB.js` agora usa conexão singleton com `connectPromise`.
- Configura pool via env (`MONGO_MAX_POOL_SIZE`, `MONGO_MIN_POOL_SIZE`, `MONGO_SERVER_SELECTION_TIMEOUT_MS`, `MONGO_SOCKET_TIMEOUT_MS`).
- Remove restart forçado com `process.exit(1)` em queda do Mongo.
- Mantém logs de conectado/desconectado/reconectado/erro como fallback operacional.

### Cache e helpers

- Adiciona `src/utils/hotPathCache.js` com TTL cache para usuário, grupo, dono e mute.
- Adiciona `src/utils/dbHelpers.js` para centralizar `ensureUser`, `ensureGroup`, updates com cache, permissão de grupo/admin/dono e invalidação.
- Adiciona `src/utils/messageMongoMetrics.js` com métrica aproximada de queries por mensagem, tempo de query e queries lentas.

### Fluxo de mensagens

- `src/events/messages.js` agora carrega user/dono/grupo de forma lazy e cacheada.
- Mensagem normal em grupo não precisa mais consultar usuário imediatamente.
- Grupo e dono são reutilizados por TTL e com dedupe de load simultâneo.
- Mute usa cache por `groupId + userLid`, com invalidação em mute/unmute.
- O handler captura erro top-level e sempre finaliza métricas.
- Auto reply reutiliza cache de grupo.

### Writes em lote

- Adiciona `src/utils/statsBatcher.js` para gravar `rankativos`, `cmdUsados` de grupo e `cmdCount` de usuário via `bulkWrite`.
- `src/utils/xp.js` passa a acumular XP por usuário e fazer batch real: `bulkWrite` para XP, leitura única por lote e `bulkWrite` para level-up quando necessário.

### Comandos e backend

- Admin/grupo/donos/economia/geral passaram a usar helpers e cache compartilhado.
- Reduz consultas duplicadas de permissão, usuário, grupo e dono.
- Atualizações de usuário/grupo agora invalidam ou atualizam cache.
- Economia usa updates atômicos onde importa, como transferência e compra de waifu.
- Backend Express virou singleton: reconectar o socket não tenta subir outra instância HTTP na mesma porta.
- `/music` usa cache de usuário e mantém refresh do token correto.

### Índices/modelos

- Adiciona índices prováveis para hot paths: grupos, donos, rankativos, mutados, adverts e users.
- Corrige defaults de datas para `Date.now` e `required` no schema de donos.

## Impacto esperado

Antes, uma mensagem comum podia acionar várias operações Mongo síncronas. Depois deste PR, mensagem comum de grupo com cache quente tende a 0 queries síncronas no Mongo, com XP/rank/stats gravados em lote.

## Validação

- `git fetch origin --prune` para integrar o `origin/main` mais recente.
- Rebase final em cima de `origin/main` (`f10f5a2`).
- `node --check` em todos os arquivos `.js`: passou.
- `git diff --check origin/main..HEAD`: passou.
- `npm test`: falha porque o projeto ainda tem script placeholder: `echo "Error: no test specified" && exit 1`.

## Observações

- O arquivo local solto `main-JhB71shj.js` não foi incluído neste PR.
- Recomendo testar em runtime com `DEBUG_MONGO_HOTPATH=true` e observar `[mongo-hotpath]`, `[mongo-cache]`, `[mongo-stats]` e `[mongo-xp]`.