### PR TITLE
feat(painel): deixei dashboard bonito no mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "redis": "^5.10.0",
         "string-similarity": "^4.0.4",
         "telegraph-uploader": "^2.0.0",
+        "three": "^0.184.0",
         "typescript": "^6.0.2",
         "whaileys": "^6.4.10",
         "ytdl-core": "^4.11.5"
@@ -793,6 +794,7 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
       "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1121,6 +1123,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -1215,6 +1218,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2768,6 +2772,19 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3012,6 +3029,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
       "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.4.0",
@@ -3240,6 +3258,49 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -3675,6 +3736,7 @@
       "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -3826,6 +3888,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
       "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
       }
@@ -4539,6 +4602,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "redis": "^5.10.0",
     "string-similarity": "^4.0.4",
     "telegraph-uploader": "^2.0.0",
+    "three": "^0.184.0",
     "typescript": "^6.0.2",
     "whaileys": "^6.4.10",
     "ytdl-core": "^4.11.5"

--- a/src/backend/controllers/user/login.js
+++ b/src/backend/controllers/user/login.js
@@ -12,7 +12,8 @@ try {
 }
 
 
-  const token_exists = await clientRedis.exists(`token:${body?.token}`);
+  const tokenKey = `token:${body.token}`;
+  const token_exists = await clientRedis.exists(tokenKey);
 
   if(!token_exists) {
 
@@ -21,7 +22,14 @@ try {
 
 }
 
- const sender = await clientRedis.get(`token:${body?.token}`);
+ const sender = await clientRedis.get(tokenKey);
+
+ if(!sender) {
+   res.status(404).json({error: "token inválido ou expirado."});
+   return;
+ }
+
+ await clientRedis.del([tokenKey, `userToken:${sender}`]);
 
  const tokenJwt = jwt.sign({sender: sender}, process.env.SECRET);
 

--- a/src/backend/controllers/user/me.js
+++ b/src/backend/controllers/user/me.js
@@ -1,0 +1,104 @@
+const { advertidos } = require("../../../database/models/adverts");
+const { grupos } = require("../../../database/models/grupos");
+const { mutados } = require("../../../database/models/mute");
+const { rankativos } = require("../../../database/models/rankativos");
+const { users } = require("../../../database/models/users");
+
+function toIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function addGroupId(set, groupId) {
+  if (typeof groupId === "string" && groupId.endsWith("@g.us")) {
+    set.add(groupId);
+  }
+}
+
+module.exports = async (req, res) => {
+  try {
+    const sender = req.user?.sender;
+
+    if(!sender) {
+      res.status(401).json({error: "usuario nao logado."});
+      return;
+    }
+
+    const [user, mutes, adverts, ranks] = await Promise.all([
+      users.findOne({userLid: sender}).lean(),
+      mutados.find({userLid: sender}).lean(),
+      advertidos.find({userLid: sender}).lean(),
+      rankativos.find({userLid: sender}).lean()
+    ]);
+
+    if(!user) {
+      res.status(404).json({error: "usuario nao encontrado."});
+      return;
+    }
+
+    const groupIds = new Set();
+    for (const group of user.grupos || []) addGroupId(groupIds, group?.id);
+    for (const mute of mutes) addGroupId(groupIds, mute?.grupo);
+    for (const adv of adverts) addGroupId(groupIds, adv?.grupo);
+    for (const rank of ranks) addGroupId(groupIds, rank?.from);
+
+    const groupDocs = groupIds.size
+      ? await grupos.find({groupId: {$in: Array.from(groupIds)}}).lean()
+      : [];
+
+    const savedGroups = new Map((user.grupos || []).map((group) => [group.id, group]));
+    const groupInfo = new Map(groupDocs.map((group) => [group.groupId, group]));
+    const muteInfo = new Map(mutes.map((mute) => [mute.grupo, mute]));
+    const advertInfo = new Map(adverts.map((adv) => [adv.grupo, adv]));
+    const rankInfo = new Map(ranks.map((rank) => [rank.from, rank]));
+
+    const groups = Array.from(groupIds).map((groupId) => {
+      const saved = savedGroups.get(groupId);
+      const group = groupInfo.get(groupId);
+      const mute = muteInfo.get(groupId);
+      const adv = advertInfo.get(groupId);
+      const rank = rankInfo.get(groupId);
+
+      return {
+        groupId,
+        name: group?.grupoName || saved?.nome || "Sem nome",
+        isAdminRegistered: !!saved,
+        muted: !!mute,
+        muteAttempts: mute?.tentativasMsg || 0,
+        advertencias: adv?.adv || 0,
+        messages: rank?.msg || 0,
+        commands: rank?.cmdUsados || 0,
+        aluguel: toIso(group?.aluguel)
+      };
+    });
+
+    res.status(200).json({
+      user: {
+        userLid: user.userLid,
+        name: user.name,
+        bio: user.bio,
+        dinheiro: user.dinheiro,
+        level: user.level,
+        xp: user.xp,
+        proximolevel: user.proximolevel,
+        isVip: !!user.isVip,
+        vencimentoVip: toIso(user.vencimentoVip),
+        registro: toIso(user.registro),
+        cmdCount: user.cmdCount,
+        downloads: user.donwloads,
+        figurinhas: user.figurinhas,
+        waifus: Array.isArray(user.waifus) ? user.waifus.length : 0,
+        conquistas: Array.isArray(user.conquistas) ? user.conquistas.length : 0,
+        discordConnected: !!user.discord_id,
+        discordName: user.discord_name || null,
+        spotifyConnected: !!user.spotifyToken?.refresh
+      },
+      groups
+    });
+  } catch(err) {
+    res.status(500).json({error: "ocorreu uma falha interna."});
+    console.error(err);
+  }
+};

--- a/src/backend/middleware/isLogin.js
+++ b/src/backend/middleware/isLogin.js
@@ -1,22 +1,20 @@
+const jwt = require("jsonwebtoken");
+
 const islogger = (req, res, next) => {
-const token = req.cookies.user;
+  const token = req.cookies.user;
 
-try {
+  try {
+    if(!token) {
+      res.status(401).json({erro: "usuario nao logado."});
+      return;
+    }
 
-if(!token) {
-  res.status(400).json({erro: "usuario nao logado."});
-return;
+    req.user = jwt.verify(token, process.env.SECRET);
+    next();
+  } catch(err) {
+    res.status(401).json({error: "token invalido."});
+    if(err?.name !== "JsonWebTokenError") console.error(err);
+  }
+};
 
-}
-
-next();
-
-}
-catch(err) {
-res.status(400).json({error: "token inválido."});
-console.error(err);
-
-}
-
-
-}
+module.exports = islogger;

--- a/src/backend/public/painel/app.js
+++ b/src/backend/public/painel/app.js
@@ -1,0 +1,148 @@
+const statusEl = document.getElementById("status");
+const errorEl = document.getElementById("error");
+const contentEl = document.getElementById("content");
+
+function setStatus(text, kind = "") {
+  statusEl.textContent = text;
+  statusEl.className = `status ${kind}`.trim();
+}
+
+function showError(text) {
+  errorEl.textContent = text;
+  errorEl.classList.remove("hidden");
+  contentEl.classList.add("hidden");
+  setStatus("Erro", "error");
+}
+
+function formatNumber(value) {
+  return Number(value || 0).toLocaleString("pt-BR");
+}
+
+function formatMoney(value) {
+  const number = Number(value || 0);
+  if (Math.abs(number) >= 1000000) {
+    return number.toLocaleString("pt-BR", {
+      notation: "compact",
+      maximumFractionDigits: 1
+    });
+  }
+
+  return number.toLocaleString("pt-BR", {
+    maximumFractionDigits: 0
+  });
+}
+
+function formatDate(value) {
+  if (!value) return "Sem data";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Sem data";
+  return date.toLocaleDateString("pt-BR");
+}
+
+async function loginWithToken(token) {
+  const response = await fetch("/auth/login", {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    credentials: "include",
+    body: JSON.stringify({token})
+  });
+
+  if (!response.ok) {
+    throw new Error("Link invalido ou expirado. Gere outro link no WhatsApp com /painel.");
+  }
+
+  window.history.replaceState({}, document.title, "/painel");
+}
+
+async function loadMe() {
+  const response = await fetch("/auth/me", {credentials: "include"});
+
+  if (!response.ok) {
+    throw new Error("Voce nao esta logado. Gere outro link no WhatsApp com /painel.");
+  }
+
+  return response.json();
+}
+
+function setChip(id, active, onText, offText) {
+  const el = document.getElementById(id);
+  el.textContent = active ? onText : offText;
+  el.className = `chip ${active ? "ok" : "off"}`;
+}
+
+function render(data) {
+  const { user, groups } = data;
+  const vipActive = user.isVip && (!user.vencimentoVip || new Date(user.vencimentoVip).getTime() >= Date.now());
+
+  document.getElementById("userName").textContent = user.name || "Sem nome";
+  document.getElementById("userLid").textContent = user.userLid;
+  document.getElementById("money").textContent = formatMoney(user.dinheiro);
+  document.getElementById("level").textContent = formatNumber(user.level);
+  document.getElementById("xp").textContent = `${formatNumber(user.xp)} / ${formatNumber(user.proximolevel)}`;
+  document.getElementById("commands").textContent = formatNumber(user.cmdCount);
+  document.getElementById("downloads").textContent = formatNumber(user.downloads);
+  document.getElementById("stickers").textContent = formatNumber(user.figurinhas);
+
+  const vipEl = document.getElementById("vipState");
+  vipEl.textContent = vipActive ? `VIP ate ${formatDate(user.vencimentoVip)}` : "VIP inativo";
+  vipEl.className = `vip ${vipActive ? "ok" : "off"}`;
+
+  setChip("discordChip", user.discordConnected, user.discordName ? `Discord: ${user.discordName}` : "Discord conectado", "Discord off");
+  setChip("spotifyChip", user.spotifyConnected, "Spotify conectado", "Spotify off");
+
+  const groupsEl = document.getElementById("groups");
+  document.getElementById("groupCount").textContent = `${groups.length} grupos`;
+
+  if (!groups.length) {
+    groupsEl.innerHTML = '<p class="muted">Nenhum grupo relacionado encontrado.</p>';
+  } else {
+    groupsEl.innerHTML = groups.map((group) => `
+      <article class="group">
+        <div>
+          <h3>${escapeHtml(group.name)}</h3>
+          <p class="muted">${escapeHtml(group.groupId)}</p>
+        </div>
+        <div class="group-meta">
+          ${group.isAdminRegistered ? '<span class="badge ok">admin registrado</span>' : '<span class="badge">sem admin salvo</span>'}
+          ${group.muted ? `<span class="badge bad">mutado (${group.muteAttempts})</span>` : '<span class="badge ok">nao mutado</span>'}
+          ${group.advertencias ? `<span class="badge warn">${group.advertencias} adv</span>` : '<span class="badge ok">sem adv</span>'}
+          <span class="badge">${formatNumber(group.messages)} msgs</span>
+          <span class="badge">${formatNumber(group.commands)} cmds</span>
+        </div>
+      </article>
+    `).join("");
+  }
+
+  errorEl.classList.add("hidden");
+  contentEl.classList.remove("hidden");
+  setStatus("Online", "ok");
+}
+
+function escapeHtml(value) {
+  return String(value || "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+async function boot() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+
+    if (token) {
+      setStatus("Entrando...");
+      await loginWithToken(token);
+    }
+
+    setStatus("Carregando...");
+    const data = await loadMe();
+    render(data);
+  } catch (err) {
+    showError(err.message || "Nao foi possivel abrir o painel.");
+  }
+}
+
+boot();

--- a/src/backend/public/painel/app.js
+++ b/src/backend/public/painel/app.js
@@ -1,6 +1,11 @@
 const statusEl = document.getElementById("status");
 const errorEl = document.getElementById("error");
 const contentEl = document.getElementById("content");
+const searchEl = document.getElementById("groupSearch");
+const segmentEls = Array.from(document.querySelectorAll(".segment"));
+
+let currentGroups = [];
+let currentFilter = "all";
 
 function setStatus(text, kind = "") {
   statusEl.textContent = text;
@@ -73,6 +78,7 @@ function setChip(id, active, onText, offText) {
 function render(data) {
   const { user, groups } = data;
   const vipActive = user.isVip && (!user.vencimentoVip || new Date(user.vencimentoVip).getTime() >= Date.now());
+  currentGroups = groups;
 
   document.getElementById("userName").textContent = user.name || "Sem nome";
   document.getElementById("userLid").textContent = user.userLid;
@@ -90,32 +96,49 @@ function render(data) {
   setChip("discordChip", user.discordConnected, user.discordName ? `Discord: ${user.discordName}` : "Discord conectado", "Discord off");
   setChip("spotifyChip", user.spotifyConnected, "Spotify conectado", "Spotify off");
 
-  const groupsEl = document.getElementById("groups");
-  document.getElementById("groupCount").textContent = `${groups.length} grupos`;
-
-  if (!groups.length) {
-    groupsEl.innerHTML = '<p class="muted">Nenhum grupo relacionado encontrado.</p>';
-  } else {
-    groupsEl.innerHTML = groups.map((group) => `
-      <article class="group">
-        <div>
-          <h3>${escapeHtml(group.name)}</h3>
-          <p class="muted">${escapeHtml(group.groupId)}</p>
-        </div>
-        <div class="group-meta">
-          ${group.isAdminRegistered ? '<span class="badge ok">admin registrado</span>' : '<span class="badge">sem admin salvo</span>'}
-          ${group.muted ? `<span class="badge bad">mutado (${group.muteAttempts})</span>` : '<span class="badge ok">nao mutado</span>'}
-          ${group.advertencias ? `<span class="badge warn">${group.advertencias} adv</span>` : '<span class="badge ok">sem adv</span>'}
-          <span class="badge">${formatNumber(group.messages)} msgs</span>
-          <span class="badge">${formatNumber(group.commands)} cmds</span>
-        </div>
-      </article>
-    `).join("");
-  }
-
+  renderGroups();
   errorEl.classList.add("hidden");
   contentEl.classList.remove("hidden");
   setStatus("Online", "ok");
+}
+
+function matchesFilter(group) {
+  if (currentFilter === "muted") return group.muted;
+  if (currentFilter === "warned") return group.advertencias > 0;
+  if (currentFilter === "admin") return group.isAdminRegistered;
+  return true;
+}
+
+function renderGroups() {
+  const groupsEl = document.getElementById("groups");
+  const query = searchEl.value.trim().toLowerCase();
+  const visibleGroups = currentGroups.filter((group) => {
+    const haystack = `${group.name} ${group.groupId}`.toLowerCase();
+    return matchesFilter(group) && (!query || haystack.includes(query));
+  });
+
+  document.getElementById("groupCount").textContent = `${visibleGroups.length} de ${currentGroups.length}`;
+
+  if (!visibleGroups.length) {
+    groupsEl.innerHTML = '<p class="empty">Nenhum grupo nesse filtro.</p>';
+    return;
+  }
+
+  groupsEl.innerHTML = visibleGroups.map((group) => `
+    <article class="group">
+      <div>
+        <h3>${escapeHtml(group.name)}</h3>
+        <p class="muted">${escapeHtml(group.groupId)}</p>
+      </div>
+      <div class="group-meta">
+        ${group.isAdminRegistered ? '<span class="badge ok">admin registrado</span>' : '<span class="badge">sem admin salvo</span>'}
+        ${group.muted ? `<span class="badge bad">mutado (${group.muteAttempts})</span>` : '<span class="badge ok">nao mutado</span>'}
+        ${group.advertencias ? `<span class="badge warn">${group.advertencias} adv</span>` : '<span class="badge ok">sem adv</span>'}
+        <span class="badge">${formatNumber(group.messages)} msgs</span>
+        <span class="badge">${formatNumber(group.commands)} cmds</span>
+      </div>
+    </article>
+  `).join("");
 }
 
 function escapeHtml(value) {
@@ -143,6 +166,16 @@ async function boot() {
   } catch (err) {
     showError(err.message || "Nao foi possivel abrir o painel.");
   }
+}
+
+searchEl.addEventListener("input", renderGroups);
+
+for (const segment of segmentEls) {
+  segment.addEventListener("click", () => {
+    currentFilter = segment.dataset.filter;
+    for (const item of segmentEls) item.classList.toggle("active", item === segment);
+    renderGroups();
+  });
 }
 
 boot();

--- a/src/backend/public/painel/index.html
+++ b/src/backend/public/painel/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Painel da Yuki</title>
+  <link rel="stylesheet" href="/painel-assets/styles.css">
+</head>
+<body>
+  <main class="app">
+    <section class="topbar">
+      <div>
+        <p class="eyebrow">Yuki</p>
+        <h1>Painel</h1>
+      </div>
+      <div id="status" class="status">Carregando...</div>
+    </section>
+
+    <section id="error" class="notice hidden"></section>
+
+    <section id="content" class="hidden">
+      <section class="summary">
+        <div>
+          <p class="label">Usuario</p>
+          <h2 id="userName">-</h2>
+          <p id="userLid" class="muted">-</p>
+        </div>
+        <div class="vip" id="vipState">VIP</div>
+      </section>
+
+      <section class="grid">
+        <article class="metric">
+          <span>Dinheiro</span>
+          <strong id="money">0</strong>
+        </article>
+        <article class="metric">
+          <span>Level</span>
+          <strong id="level">0</strong>
+        </article>
+        <article class="metric">
+          <span>XP</span>
+          <strong id="xp">0</strong>
+        </article>
+        <article class="metric">
+          <span>Comandos</span>
+          <strong id="commands">0</strong>
+        </article>
+        <article class="metric">
+          <span>Downloads</span>
+          <strong id="downloads">0</strong>
+        </article>
+        <article class="metric">
+          <span>Figurinhas</span>
+          <strong id="stickers">0</strong>
+        </article>
+      </section>
+
+      <section class="panel">
+        <div class="panel-title">
+          <h2>Conexoes</h2>
+        </div>
+        <div class="chips">
+          <span id="discordChip" class="chip">Discord</span>
+          <span id="spotifyChip" class="chip">Spotify</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-title">
+          <h2>Grupos</h2>
+          <span id="groupCount" class="muted">0</span>
+        </div>
+        <div id="groups" class="groups"></div>
+      </section>
+    </section>
+  </main>
+
+  <script src="/painel-assets/app.js"></script>
+</body>
+</html>

--- a/src/backend/public/painel/index.html
+++ b/src/backend/public/painel/index.html
@@ -4,59 +4,70 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Painel da Yuki</title>
+  <link rel="icon" href="data:,">
   <link rel="stylesheet" href="/painel-assets/styles.css">
 </head>
 <body>
+  <canvas id="yukiScene" aria-hidden="true"></canvas>
+  <div class="atmosphere" aria-hidden="true"></div>
+
   <main class="app">
-    <section class="topbar">
-      <div>
-        <p class="eyebrow">Yuki</p>
-        <h1>Painel</h1>
+    <section class="topbar glass">
+      <div class="brand">
+        <span class="brand-mark">Y</span>
+        <div>
+          <p class="eyebrow">Yuki web</p>
+          <h1>Painel</h1>
+        </div>
       </div>
       <div id="status" class="status">Carregando...</div>
     </section>
 
     <section id="error" class="notice hidden"></section>
 
-    <section id="content" class="hidden">
-      <section class="summary">
-        <div>
-          <p class="label">Usuario</p>
+    <section id="content" class="workspace hidden">
+      <section class="identity glass">
+        <div class="identity-copy">
+          <p class="eyebrow">Sessao reconhecida</p>
           <h2 id="userName">-</h2>
           <p id="userLid" class="muted">-</p>
         </div>
-        <div class="vip" id="vipState">VIP</div>
+        <div class="identity-side">
+          <span class="orbital-label">Yuki</span>
+          <div class="vip" id="vipState">VIP</div>
+        </div>
       </section>
 
-      <section class="grid">
-        <article class="metric">
+      <section class="metrics" aria-label="Resumo do usuario">
+        <article class="metric glass accent">
           <span>Dinheiro</span>
           <strong id="money">0</strong>
         </article>
-        <article class="metric">
+        <article class="metric glass">
           <span>Level</span>
           <strong id="level">0</strong>
         </article>
-        <article class="metric">
+        <article class="metric glass">
           <span>XP</span>
           <strong id="xp">0</strong>
         </article>
-        <article class="metric">
+        <article class="metric glass">
           <span>Comandos</span>
           <strong id="commands">0</strong>
         </article>
-        <article class="metric">
+        <article class="metric glass">
           <span>Downloads</span>
           <strong id="downloads">0</strong>
         </article>
-        <article class="metric">
+        <article class="metric glass">
           <span>Figurinhas</span>
           <strong id="stickers">0</strong>
         </article>
       </section>
 
-      <section class="panel">
-        <div class="panel-title">
+      <section class="connections glass">
+        <div>
+          <p class="eyebrow">Vinculos</p>
           <h2>Conexoes</h2>
         </div>
         <div class="chips">
@@ -65,16 +76,41 @@
         </div>
       </section>
 
-      <section class="panel">
-        <div class="panel-title">
-          <h2>Grupos</h2>
+      <section class="groups-panel glass">
+        <div class="panel-head">
+          <div>
+            <p class="eyebrow">Situacao por grupo</p>
+            <h2>Grupos</h2>
+          </div>
           <span id="groupCount" class="muted">0</span>
         </div>
+
+        <div class="tools">
+          <label class="search">
+            <span>Buscar</span>
+            <input id="groupSearch" type="search" autocomplete="off" placeholder="Nome ou ID do grupo">
+          </label>
+          <div class="segments" aria-label="Filtro dos grupos">
+            <button class="segment active" data-filter="all" type="button">Todos</button>
+            <button class="segment" data-filter="muted" type="button">Mutado</button>
+            <button class="segment" data-filter="warned" type="button">Adv</button>
+            <button class="segment" data-filter="admin" type="button">Admin</button>
+          </div>
+        </div>
+
         <div id="groups" class="groups"></div>
       </section>
     </section>
   </main>
 
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "/painel-vendor/three/three.module.js"
+      }
+    }
+  </script>
+  <script type="module" src="/painel-assets/scene.mjs"></script>
   <script src="/painel-assets/app.js"></script>
 </body>
 </html>

--- a/src/backend/public/painel/scene.mjs
+++ b/src/backend/public/painel/scene.mjs
@@ -1,0 +1,111 @@
+import * as THREE from "three";
+
+const canvas = document.getElementById("yukiScene");
+const renderer = new THREE.WebGLRenderer({canvas, antialias: true, alpha: true, preserveDrawingBuffer: true});
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(45, 1, 0.1, 100);
+const pointer = new THREE.Vector2(0, 0);
+const startedAt = performance.now();
+
+camera.position.set(0, 0, 7.5);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 1.8));
+
+const group = new THREE.Group();
+scene.add(group);
+
+const coreMaterial = new THREE.MeshPhysicalMaterial({
+  color: 0x78d7ff,
+  roughness: 0.18,
+  metalness: 0.1,
+  transmission: 0.46,
+  thickness: 0.6,
+  transparent: true,
+  opacity: 0.52,
+  emissive: 0x102b3a,
+  emissiveIntensity: 0.8
+});
+
+const shellMaterial = new THREE.MeshBasicMaterial({
+  color: 0x67f0b2,
+  transparent: true,
+  opacity: 0.14,
+  wireframe: true
+});
+
+const core = new THREE.Mesh(new THREE.IcosahedronGeometry(1.35, 3), coreMaterial);
+const shell = new THREE.Mesh(new THREE.IcosahedronGeometry(1.92, 2), shellMaterial);
+group.add(core, shell);
+
+const ringMaterial = new THREE.MeshBasicMaterial({
+  color: 0x78d7ff,
+  transparent: true,
+  opacity: 0.26,
+  side: THREE.DoubleSide
+});
+
+for (let index = 0; index < 3; index++) {
+  const ring = new THREE.Mesh(new THREE.TorusGeometry(2.35 + index * 0.35, 0.006, 8, 160), ringMaterial);
+  ring.rotation.x = Math.PI / 2 + index * 0.46;
+  ring.rotation.y = index * 0.72;
+  group.add(ring);
+}
+
+const particleCount = 320;
+const positions = new Float32Array(particleCount * 3);
+for (let index = 0; index < particleCount; index++) {
+  const radius = 2.8 + Math.random() * 4.8;
+  const angle = Math.random() * Math.PI * 2;
+  const y = (Math.random() - 0.5) * 4.6;
+  positions[index * 3] = Math.cos(angle) * radius;
+  positions[index * 3 + 1] = y;
+  positions[index * 3 + 2] = Math.sin(angle) * radius - 1.2;
+}
+
+const particles = new THREE.Points(
+  new THREE.BufferGeometry().setAttribute("position", new THREE.BufferAttribute(positions, 3)),
+  new THREE.PointsMaterial({
+    color: 0x9bdfff,
+    size: 0.025,
+    transparent: true,
+    opacity: 0.46,
+    depthWrite: false
+  })
+);
+scene.add(particles);
+
+const light = new THREE.PointLight(0x9bdfff, 18, 20);
+light.position.set(2.5, 2.5, 4);
+scene.add(light);
+scene.add(new THREE.AmbientLight(0x5a6d78, 1.4));
+
+function resize() {
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+  renderer.setSize(width, height, false);
+
+  const isMobile = width < 720;
+  group.position.set(isMobile ? 1.45 : 4.35, isMobile ? 1.85 : 1.32, isMobile ? -1.2 : -0.2);
+  group.scale.setScalar(isMobile ? 0.66 : 1);
+}
+
+function animate() {
+  const elapsed = (performance.now() - startedAt) / 1000;
+  group.rotation.x = elapsed * 0.08 + pointer.y * 0.18;
+  group.rotation.y = elapsed * 0.13 + pointer.x * 0.22;
+  shell.rotation.y = -elapsed * 0.18;
+  particles.rotation.y = elapsed * 0.018;
+  particles.rotation.x = Math.sin(elapsed * 0.2) * 0.04;
+  renderer.render(scene, camera);
+  requestAnimationFrame(animate);
+}
+
+window.addEventListener("resize", resize);
+window.addEventListener("pointermove", (event) => {
+  pointer.x = (event.clientX / window.innerWidth - 0.5) * 2;
+  pointer.y = (event.clientY / window.innerHeight - 0.5) * -2;
+});
+
+resize();
+animate();

--- a/src/backend/public/painel/styles.css
+++ b/src/backend/public/painel/styles.css
@@ -1,0 +1,237 @@
+:root {
+  color-scheme: dark;
+  --bg: #111315;
+  --panel: #191d20;
+  --panel-2: #20252a;
+  --text: #f1f5f7;
+  --muted: #94a0aa;
+  --line: #30373d;
+  --ok: #66d18f;
+  --warn: #f7c66a;
+  --bad: #ff7c7c;
+  --accent: #8fc7ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.app {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 28px 0 40px;
+}
+
+.topbar,
+.summary,
+.panel,
+.metric {
+  border: 1px solid var(--line);
+  background: var(--panel);
+  border-radius: 8px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 20px;
+  margin-bottom: 16px;
+}
+
+.eyebrow,
+.label,
+.muted {
+  color: var(--muted);
+}
+
+.eyebrow,
+.label {
+  margin: 0 0 4px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+
+h1,
+h2,
+p {
+  margin: 0;
+}
+
+h1 {
+  font-size: 28px;
+  line-height: 1.15;
+}
+
+h2 {
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.status,
+.vip,
+.chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 7px 10px;
+  font-size: 13px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.status.ok,
+.chip.ok,
+.vip.ok {
+  color: var(--ok);
+  border-color: rgba(102, 209, 143, .45);
+}
+
+.status.error,
+.chip.off,
+.vip.off {
+  color: var(--bad);
+  border-color: rgba(255, 124, 124, .45);
+}
+
+.notice {
+  border: 1px solid rgba(255, 124, 124, .45);
+  background: rgba(255, 124, 124, .08);
+  color: var(--text);
+  padding: 14px;
+  border-radius: 8px;
+}
+
+.summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 20px;
+  margin-bottom: 16px;
+}
+
+.summary .muted {
+  margin-top: 6px;
+  word-break: break-word;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.metric {
+  padding: 14px;
+  min-height: 86px;
+}
+
+.metric span {
+  display: block;
+  color: var(--muted);
+  font-size: 13px;
+  margin-bottom: 10px;
+}
+
+.metric strong {
+  font-size: 24px;
+  line-height: 1;
+  overflow-wrap: anywhere;
+}
+
+.panel {
+  padding: 16px;
+  margin-bottom: 16px;
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.chips,
+.groups {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.groups {
+  flex-direction: column;
+}
+
+.group {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  background: var(--panel-2);
+  border-radius: 8px;
+}
+
+.group h3 {
+  margin: 0 0 8px;
+  font-size: 15px;
+}
+
+.group-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge {
+  border: 1px solid var(--line);
+  color: var(--muted);
+  border-radius: 999px;
+  padding: 5px 8px;
+  font-size: 12px;
+}
+
+.badge.bad {
+  color: var(--bad);
+  border-color: rgba(255, 124, 124, .45);
+}
+
+.badge.warn {
+  color: var(--warn);
+  border-color: rgba(247, 198, 106, .45);
+}
+
+.badge.ok {
+  color: var(--ok);
+  border-color: rgba(102, 209, 143, .45);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 820px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .topbar,
+  .summary,
+  .group {
+    grid-template-columns: 1fr;
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/backend/public/painel/styles.css
+++ b/src/backend/public/painel/styles.css
@@ -1,51 +1,117 @@
 :root {
   color-scheme: dark;
-  --bg: #111315;
-  --panel: #191d20;
-  --panel-2: #20252a;
-  --text: #f1f5f7;
-  --muted: #94a0aa;
-  --line: #30373d;
-  --ok: #66d18f;
-  --warn: #f7c66a;
-  --bad: #ff7c7c;
-  --accent: #8fc7ff;
+  --bg: #080b0d;
+  --glass: rgba(18, 24, 29, .58);
+  --glass-strong: rgba(24, 31, 37, .78);
+  --line: rgba(193, 225, 255, .14);
+  --line-strong: rgba(193, 225, 255, .26);
+  --text: #f4f8fb;
+  --muted: #8fb0c5;
+  --soft: #c8ddeb;
+  --accent: #78d7ff;
+  --accent-2: #67f0b2;
+  --warn: #ffd66b;
+  --bad: #ff7d8a;
+  --shadow: 0 24px 80px rgba(0, 0, 0, .42);
+  --radius: 8px;
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  min-height: 100%;
+  background: var(--bg);
+}
+
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--bg);
   color: var(--text);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  overflow-x: hidden;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -3;
+  background:
+    radial-gradient(circle at 50% -20%, rgba(120, 215, 255, .16), transparent 35%),
+    linear-gradient(135deg, #071013 0%, #101417 45%, #080b0d 100%);
+}
+
+#yukiScene {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.atmosphere {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    linear-gradient(180deg, rgba(8, 11, 13, .1), rgba(8, 11, 13, .9) 72%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, .025) 0 1px, transparent 1px 84px);
+  mask-image: linear-gradient(180deg, #000 0%, rgba(0, 0, 0, .92) 58%, rgba(0, 0, 0, .72) 100%);
 }
 
 .app {
-  width: min(1120px, calc(100% - 32px));
+  width: min(1180px, calc(100% - 32px));
   margin: 0 auto;
-  padding: 28px 0 40px;
+  padding: 24px 0 56px;
+}
+
+.glass {
+  border: 1px solid var(--line);
+  background: var(--glass);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(22px) saturate(140%);
+  -webkit-backdrop-filter: blur(22px) saturate(140%);
+  border-radius: var(--radius);
 }
 
 .topbar,
-.summary,
-.panel,
-.metric {
-  border: 1px solid var(--line);
-  background: var(--panel);
-  border-radius: 8px;
-}
-
-.topbar {
+.identity,
+.connections,
+.panel-head,
+.tools {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 20px;
+}
+
+.topbar {
+  padding: 16px;
   margin-bottom: 16px;
+  animation: rise .5s ease both;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border: 1px solid rgba(120, 215, 255, .42);
+  border-radius: 50%;
+  color: var(--accent);
+  background: rgba(120, 215, 255, .08);
+  font-weight: 800;
 }
 
 .eyebrow,
@@ -54,124 +120,243 @@ body {
   color: var(--muted);
 }
 
-.eyebrow,
-.label {
+.eyebrow {
   margin: 0 0 4px;
-  font-size: 12px;
+  font-size: 11px;
   text-transform: uppercase;
-  letter-spacing: 0;
+  letter-spacing: .08em;
 }
 
 h1,
 h2,
+h3,
 p {
   margin: 0;
 }
 
 h1 {
-  font-size: 28px;
-  line-height: 1.15;
+  font-size: clamp(30px, 5vw, 54px);
+  line-height: .95;
 }
 
 h2 {
-  font-size: 18px;
-  line-height: 1.25;
+  font-size: clamp(19px, 2.5vw, 26px);
+  line-height: 1.1;
 }
 
 .status,
 .vip,
-.chip {
+.chip,
+.badge,
+.segment {
   border: 1px solid var(--line);
   border-radius: 999px;
-  padding: 7px 10px;
+  padding: 8px 11px;
   font-size: 13px;
   color: var(--muted);
   white-space: nowrap;
+  background: rgba(8, 11, 13, .28);
 }
 
 .status.ok,
 .chip.ok,
-.vip.ok {
-  color: var(--ok);
-  border-color: rgba(102, 209, 143, .45);
+.vip.ok,
+.badge.ok {
+  color: var(--accent-2);
+  border-color: rgba(103, 240, 178, .48);
+  background: rgba(103, 240, 178, .07);
 }
 
 .status.error,
 .chip.off,
-.vip.off {
+.vip.off,
+.badge.bad {
   color: var(--bad);
-  border-color: rgba(255, 124, 124, .45);
+  border-color: rgba(255, 125, 138, .5);
+  background: rgba(255, 125, 138, .07);
 }
 
 .notice {
-  border: 1px solid rgba(255, 124, 124, .45);
-  background: rgba(255, 124, 124, .08);
+  border: 1px solid rgba(255, 125, 138, .5);
+  background: rgba(255, 125, 138, .1);
   color: var(--text);
-  padding: 14px;
-  border-radius: 8px;
+  padding: 15px;
+  border-radius: var(--radius);
+  backdrop-filter: blur(16px);
 }
 
-.summary {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-  padding: 20px;
-  margin-bottom: 16px;
-}
-
-.summary .muted {
-  margin-top: 6px;
-  word-break: break-word;
-}
-
-.grid {
+.workspace {
   display: grid;
-  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.identity {
+  min-height: 168px;
+  padding: clamp(18px, 4vw, 34px);
+  background:
+    linear-gradient(115deg, rgba(24, 31, 37, .86), rgba(24, 31, 37, .46)),
+    linear-gradient(90deg, rgba(120, 215, 255, .13), transparent 52%);
+  overflow: hidden;
+  position: relative;
+  animation: rise .58s .04s ease both;
+}
+
+.identity::after {
+  content: "";
+  position: absolute;
+  inset: auto -12% -65% auto;
+  width: 420px;
+  aspect-ratio: 1;
+  border: 1px solid rgba(120, 215, 255, .24);
+  border-radius: 50%;
+  transform: rotateX(70deg);
+}
+
+.identity-copy {
+  min-width: 0;
+  position: relative;
+  z-index: 1;
+}
+
+.identity-copy h2 {
+  font-size: clamp(32px, 8vw, 76px);
+  line-height: .9;
+  letter-spacing: 0;
+  margin-bottom: 10px;
+  overflow-wrap: anywhere;
+}
+
+.identity-copy .muted {
+  color: #9bc8e5;
+  overflow-wrap: anywhere;
+}
+
+.identity-side {
+  display: grid;
+  justify-items: end;
   gap: 12px;
-  margin-bottom: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.orbital-label {
+  color: rgba(244, 248, 251, .16);
+  font-size: clamp(52px, 12vw, 128px);
+  line-height: .8;
+  font-weight: 900;
+  letter-spacing: 0;
+}
+
+.metrics {
+  display: grid;
+  grid-template-columns: 1.3fr repeat(5, 1fr);
+  gap: 12px;
 }
 
 .metric {
-  padding: 14px;
-  min-height: 86px;
+  padding: 16px;
+  min-height: 112px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  animation: rise .48s ease both;
+}
+
+.metric:nth-child(2) { animation-delay: .03s; }
+.metric:nth-child(3) { animation-delay: .06s; }
+.metric:nth-child(4) { animation-delay: .09s; }
+.metric:nth-child(5) { animation-delay: .12s; }
+.metric:nth-child(6) { animation-delay: .15s; }
+
+.metric.accent {
+  border-color: rgba(120, 215, 255, .35);
+  background: linear-gradient(145deg, rgba(120, 215, 255, .14), rgba(18, 24, 29, .62));
 }
 
 .metric span {
-  display: block;
   color: var(--muted);
   font-size: 13px;
-  margin-bottom: 10px;
 }
 
 .metric strong {
-  font-size: 24px;
+  font-size: clamp(25px, 3vw, 38px);
   line-height: 1;
   overflow-wrap: anywhere;
 }
 
-.panel {
-  padding: 16px;
-  margin-bottom: 16px;
+.connections,
+.groups-panel {
+  padding: 18px;
+  animation: rise .55s .08s ease both;
 }
 
-.panel-title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 14px;
-}
-
-.chips,
-.groups {
+.chips {
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 10px;
 }
 
+.groups-panel {
+  display: grid;
+  gap: 16px;
+}
+
+.tools {
+  align-items: flex-end;
+  padding-top: 2px;
+}
+
+.search {
+  display: grid;
+  gap: 7px;
+  width: min(380px, 100%);
+  color: var(--muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+}
+
+.search input {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--text);
+  background: rgba(8, 11, 13, .42);
+  padding: 0 15px;
+  outline: none;
+}
+
+.search input:focus {
+  border-color: rgba(120, 215, 255, .56);
+}
+
+.segments {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.segment {
+  cursor: pointer;
+  transition: transform .18s ease, border-color .18s ease, color .18s ease, background .18s ease;
+}
+
+.segment.active {
+  color: var(--text);
+  border-color: rgba(120, 215, 255, .55);
+  background: rgba(120, 215, 255, .13);
+}
+
+.segment:active {
+  transform: scale(.96);
+}
+
 .groups {
-  flex-direction: column;
+  display: grid;
+  gap: 10px;
 }
 
 .group {
@@ -180,58 +365,172 @@ h2 {
   gap: 12px;
   padding: 14px;
   border: 1px solid var(--line);
-  background: var(--panel-2);
-  border-radius: 8px;
+  background: rgba(8, 11, 13, .35);
+  border-radius: var(--radius);
+  transition: transform .2s ease, border-color .2s ease, background .2s ease;
+}
+
+.group:hover {
+  transform: translateY(-2px);
+  border-color: var(--line-strong);
+  background: rgba(15, 22, 28, .56);
 }
 
 .group h3 {
   margin: 0 0 8px;
   font-size: 15px;
+  line-height: 1.2;
+}
+
+.group .muted {
+  overflow-wrap: anywhere;
 }
 
 .group-meta {
   display: flex;
   flex-wrap: wrap;
+  align-content: center;
+  justify-content: flex-end;
   gap: 8px;
 }
 
 .badge {
-  border: 1px solid var(--line);
-  color: var(--muted);
-  border-radius: 999px;
-  padding: 5px 8px;
   font-size: 12px;
-}
-
-.badge.bad {
-  color: var(--bad);
-  border-color: rgba(255, 124, 124, .45);
+  padding: 6px 8px;
 }
 
 .badge.warn {
   color: var(--warn);
-  border-color: rgba(247, 198, 106, .45);
+  border-color: rgba(255, 214, 107, .5);
+  background: rgba(255, 214, 107, .07);
 }
 
-.badge.ok {
-  color: var(--ok);
-  border-color: rgba(102, 209, 143, .45);
+.empty {
+  color: var(--muted);
+  padding: 18px 0 4px;
 }
 
 .hidden {
   display: none;
 }
 
-@media (max-width: 820px) {
-  .grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+@keyframes rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: .01ms !important;
+  }
+}
+
+@media (max-width: 980px) {
+  .metrics {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .app {
+    width: min(100% - 24px, 520px);
+    padding: 14px 0 32px;
   }
 
   .topbar,
-  .summary,
+  .identity,
+  .connections,
+  .panel-head,
+  .tools,
   .group {
-    grid-template-columns: 1fr;
-    flex-direction: column;
     align-items: stretch;
+    flex-direction: column;
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    gap: 14px;
+  }
+
+  .status,
+  .vip {
+    text-align: center;
+    width: 100%;
+  }
+
+  .identity {
+    min-height: 158px;
+  }
+
+  .identity-side {
+    justify-items: stretch;
+  }
+
+  .orbital-label {
+    display: none;
+  }
+
+  .metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .metric {
+    min-height: 104px;
+    padding: 14px;
+  }
+
+  .metric strong {
+    font-size: 27px;
+  }
+
+  .chips,
+  .segments,
+  .group-meta {
+    justify-content: flex-start;
+  }
+
+  .groups-panel,
+  .connections {
+    padding: 16px;
+  }
+
+  .group {
+    padding: 13px;
+  }
+
+  .badge {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+}
+
+@media (max-width: 390px) {
+  .app {
+    width: min(100% - 18px, 520px);
+  }
+
+  .metrics {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .metric strong {
+    font-size: 24px;
+  }
+
+  .brand-mark {
+    width: 38px;
+    height: 38px;
   }
 }

--- a/src/backend/routes/user.js
+++ b/src/backend/routes/user.js
@@ -3,6 +3,7 @@ const express = require("express");
 const router = express.Router();
 const isLogin = require("../middleware/isLogin");
 const user_info = require("../controllers/user/userInfo.js");
+const me = require("../controllers/user/me.js");
 const setName = require("../controllers/user/setName.js");
 const discord_auth = require('../controllers/user/discordAuth.js');
 
@@ -10,6 +11,8 @@ const discord_auth = require('../controllers/user/discordAuth.js');
 router.post("/login", login);
 
 router.get("/user", user_info);
+
+router.get("/me", isLogin, me);
 
 router.post("/set-name", setName);
 

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -3,6 +3,7 @@ const { clientRedis } = require("../lib/redis.js");
 const { payment } = require("../lib/mercadoPago.js");
 const { numberOwner } = require("../config.js");
 const axios = require("axios");
+const path = require("path");
 const { getUserCached, updateGroupAndCache, updateUserAndCache } = require("../utils/dbHelpers.js");
 const userRouter = require("./routes/user.js");
 const cors = require("cors");
@@ -54,6 +55,9 @@ credentials: true
   
   app.use(cookieParser());
 
+  const publicDir = path.join(__dirname, "public");
+  app.use("/painel-assets", express.static(path.join(publicDir, "painel")));
+
   app.use((req, res, next) => {
 
 console.log("req recebida!");
@@ -67,6 +71,10 @@ next()
   
   app.get("/", async (req, res) => {
     await res.status(200).json({res: "ok!"});
+  });
+
+  app.get("/painel", (req, res) => {
+    res.sendFile(path.join(publicDir, "painel", "index.html"));
   });
   
   app.use("/auth", userRouter);

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -57,6 +57,7 @@ credentials: true
 
   const publicDir = path.join(__dirname, "public");
   app.use("/painel-assets", express.static(path.join(publicDir, "painel")));
+  app.use("/painel-vendor/three", express.static(path.join(__dirname, "../../node_modules/three/build")));
 
   app.use((req, res, next) => {
 

--- a/src/commands/geral/painel.js
+++ b/src/commands/geral/painel.js
@@ -1,0 +1,39 @@
+const crypto = require("crypto");
+const { clientRedis } = require("../../lib/redis.js");
+
+module.exports = {
+  name: "painel",
+  categoria: "padrao",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      const baseUrl = process.env.URL_BACKEND;
+
+      if(!baseUrl) {
+        await bot.reply(from, "URL do painel nao configurada.");
+        return;
+      }
+
+      const existeToken = await clientRedis.exists(`userToken:${sender}`);
+
+      if(existeToken) {
+        await bot.reply(from, "Voce ja tem um link pendente no privado. Ele expira em 5 minutos.");
+        return;
+      }
+
+      const msgEspera = await bot.reply(from, "Gerando link do painel...");
+      const token = crypto.randomBytes(32).toString("hex");
+
+      await clientRedis.set(`token:${token}`, sender, {EX: 300});
+      await clientRedis.set(`userToken:${sender}`, token, {EX: 300});
+
+      const url = new URL("/painel", baseUrl);
+      url.searchParams.set("token", token);
+
+      await bot.reply(sender, `Seu painel da Yuki: ${url.toString()}\n\nEsse link expira em 5 minutos e funciona uma vez so.`);
+      await bot.editReply(from, msgEspera.key, "Link do painel enviado no seu privado!");
+    } catch(err) {
+      await bot.reply(from, erros_prontos);
+      console.error(err);
+    }
+  }
+};


### PR DESCRIPTION
## Resumo
- deixei o painel responsivo para mobile e desktop
- adicionei uma cena 3D com Three.js no fundo do painel
- refinei a UI com vidro, blur, transparencias, filtros e busca nos grupos
- mantive o fluxo seguro por token temporario e cookie httpOnly

## Testes
- node --check nos arquivos alterados
- login com token valido limpa a URL e carrega os dados do proprio sender
- reuso do token retorna 404
- /auth/me sem cookie retorna 401
- /auth/me com cookie invalido retorna 401
- QA visual desktop e mobile com Playwright
- canvas WebGL com pixels renderizados em desktop e mobile
- sem overflow horizontal no mobile