### PR TITLE
feat(painel): adiciono acoes administrativas

### DIFF
--- a/src/backend/controllers/user/login.js
+++ b/src/backend/controllers/user/login.js
@@ -1,4 +1,5 @@
 const { clientRedis } = require("../../../lib/redis.js");
+const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
 
 module.exports = async (req, res)  => {
@@ -31,7 +32,8 @@ try {
 
  await clientRedis.del([tokenKey, `userToken:${sender}`]);
 
- const tokenJwt = jwt.sign({sender: sender}, process.env.SECRET);
+ const csrfToken = crypto.randomBytes(32).toString("hex");
+ const tokenJwt = jwt.sign({sender: sender, csrfToken}, process.env.SECRET);
 
 const isProd = process.env.DEV_AMBIENT === "false";
 

--- a/src/backend/controllers/user/me.js
+++ b/src/backend/controllers/user/me.js
@@ -1,21 +1,4 @@
-const { advertidos } = require("../../../database/models/adverts");
-const { grupos } = require("../../../database/models/grupos");
-const { mutados } = require("../../../database/models/mute");
-const { rankativos } = require("../../../database/models/rankativos");
-const { users } = require("../../../database/models/users");
-
-function toIso(value) {
-  if (!value) return null;
-  const date = value instanceof Date ? value : new Date(value);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toISOString();
-}
-
-function addGroupId(set, groupId) {
-  if (typeof groupId === "string" && groupId.endsWith("@g.us")) {
-    set.add(groupId);
-  }
-}
+const { buildPanelHome } = require("../../services/panelService");
 
 module.exports = async (req, res) => {
   try {
@@ -26,79 +9,11 @@ module.exports = async (req, res) => {
       return;
     }
 
-    const [user, mutes, adverts, ranks] = await Promise.all([
-      users.findOne({userLid: sender}).lean(),
-      mutados.find({userLid: sender}).lean(),
-      advertidos.find({userLid: sender}).lean(),
-      rankativos.find({userLid: sender}).lean()
-    ]);
-
-    if(!user) {
-      res.status(404).json({error: "usuario nao encontrado."});
-      return;
-    }
-
-    const groupIds = new Set();
-    for (const group of user.grupos || []) addGroupId(groupIds, group?.id);
-    for (const mute of mutes) addGroupId(groupIds, mute?.grupo);
-    for (const adv of adverts) addGroupId(groupIds, adv?.grupo);
-    for (const rank of ranks) addGroupId(groupIds, rank?.from);
-
-    const groupDocs = groupIds.size
-      ? await grupos.find({groupId: {$in: Array.from(groupIds)}}).lean()
-      : [];
-
-    const savedGroups = new Map((user.grupos || []).map((group) => [group.id, group]));
-    const groupInfo = new Map(groupDocs.map((group) => [group.groupId, group]));
-    const muteInfo = new Map(mutes.map((mute) => [mute.grupo, mute]));
-    const advertInfo = new Map(adverts.map((adv) => [adv.grupo, adv]));
-    const rankInfo = new Map(ranks.map((rank) => [rank.from, rank]));
-
-    const groups = Array.from(groupIds).map((groupId) => {
-      const saved = savedGroups.get(groupId);
-      const group = groupInfo.get(groupId);
-      const mute = muteInfo.get(groupId);
-      const adv = advertInfo.get(groupId);
-      const rank = rankInfo.get(groupId);
-
-      return {
-        groupId,
-        name: group?.grupoName || saved?.nome || "Sem nome",
-        isAdminRegistered: !!saved,
-        muted: !!mute,
-        muteAttempts: mute?.tentativasMsg || 0,
-        advertencias: adv?.adv || 0,
-        messages: rank?.msg || 0,
-        commands: rank?.cmdUsados || 0,
-        aluguel: toIso(group?.aluguel)
-      };
-    });
-
-    res.status(200).json({
-      user: {
-        userLid: user.userLid,
-        name: user.name,
-        bio: user.bio,
-        dinheiro: user.dinheiro,
-        level: user.level,
-        xp: user.xp,
-        proximolevel: user.proximolevel,
-        isVip: !!user.isVip,
-        vencimentoVip: toIso(user.vencimentoVip),
-        registro: toIso(user.registro),
-        cmdCount: user.cmdCount,
-        downloads: user.donwloads,
-        figurinhas: user.figurinhas,
-        waifus: Array.isArray(user.waifus) ? user.waifus.length : 0,
-        conquistas: Array.isArray(user.conquistas) ? user.conquistas.length : 0,
-        discordConnected: !!user.discord_id,
-        discordName: user.discord_name || null,
-        spotifyConnected: !!user.spotifyToken?.refresh
-      },
-      groups
-    });
+    const data = await buildPanelHome(sender, req.activeSock);
+    data.csrfToken = req.user?.csrfToken || null;
+    res.status(200).json(data);
   } catch(err) {
-    res.status(500).json({error: "ocorreu uma falha interna."});
-    console.error(err);
+    res.status(err?.status || 500).json({error: err?.message || "ocorreu uma falha interna."});
+    if((err?.status || 500) >= 500) console.error(err);
   }
 };

--- a/src/backend/controllers/user/panel.js
+++ b/src/backend/controllers/user/panel.js
@@ -1,0 +1,93 @@
+const {
+  confirmAnnouncement,
+  createAnnouncementPreview,
+  decodeGroupId,
+  getGroupPanel,
+  runGroupAction,
+  updateGroupConfig
+} = require("../../services/panelService");
+
+function getSender(req) {
+  const sender = req.user?.sender;
+  if (!sender) throw Object.assign(new Error("usuario nao logado."), {status: 401});
+  return sender;
+}
+
+function assertCsrf(req) {
+  const expected = req.user?.csrfToken;
+  const received = req.headers["x-csrf-token"];
+  if (!expected || !received || expected !== received) {
+    throw Object.assign(new Error("csrf invalido."), {status: 403});
+  }
+}
+
+function sendError(res, err) {
+  const status = err?.status || 500;
+  res.status(status).json({error: err?.message || "ocorreu uma falha interna."});
+  if (status >= 500) console.error(err);
+}
+
+async function groupDetails(req, res) {
+  try {
+    const sender = getSender(req);
+    const groupId = decodeGroupId(req.params.groupId);
+    const data = await getGroupPanel(req.activeSock, groupId, sender);
+    res.status(200).json(data);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function updateConfig(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const groupId = decodeGroupId(req.params.groupId);
+    const group = await updateGroupConfig(req.activeSock, groupId, sender, req.body || {});
+    res.status(200).json({group});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function groupAction(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const groupId = decodeGroupId(req.params.groupId);
+    const result = await runGroupAction(req.activeSock, groupId, sender, req.body || {});
+    res.status(200).json(result);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function announcementPreview(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const preview = await createAnnouncementPreview(sender, req.body || {});
+    res.status(200).json({preview});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function announcementConfirm(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const result = await confirmAnnouncement(req.activeSock, sender, req.body?.previewId);
+    res.status(202).json(result);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+module.exports = {
+  announcementConfirm,
+  announcementPreview,
+  groupAction,
+  groupDetails,
+  updateConfig
+};

--- a/src/backend/public/painel/app.js
+++ b/src/backend/public/painel/app.js
@@ -1,11 +1,38 @@
 const statusEl = document.getElementById("status");
 const errorEl = document.getElementById("error");
 const contentEl = document.getElementById("content");
-const searchEl = document.getElementById("groupSearch");
-const segmentEls = Array.from(document.querySelectorAll(".segment"));
+const tabsEl = document.getElementById("tabs");
 
-let currentGroups = [];
-let currentFilter = "all";
+const views = {
+  profile: document.getElementById("viewProfile"),
+  groups: document.getElementById("viewGroups"),
+  config: document.getElementById("viewConfig"),
+  moderation: document.getElementById("viewModeration"),
+  ops: document.getElementById("viewOps"),
+  announcements: document.getElementById("viewAnnouncements")
+};
+
+const state = {
+  activeTab: "profile",
+  csrfToken: null,
+  user: null,
+  permissions: {},
+  groups: [],
+  ops: {},
+  selectedGroupId: null,
+  selectedGroup: null,
+  groupDetails: null,
+  announcementPreview: null
+};
+
+const tabDefs = [
+  {id: "profile", label: "Perfil"},
+  {id: "groups", label: "Grupos"},
+  {id: "config", label: "Config", needsGroup: true},
+  {id: "moderation", label: "Moderacao", needsGroup: true},
+  {id: "ops", label: "Ops", needsOps: true},
+  {id: "announcements", label: "Anuncios", needsAnnouncements: true}
+];
 
 function setStatus(text, kind = "") {
   statusEl.textContent = text;
@@ -19,6 +46,19 @@ function showError(text) {
   setStatus("Erro", "error");
 }
 
+function clearError() {
+  errorEl.classList.add("hidden");
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
 function formatNumber(value) {
   return Number(value || 0).toLocaleString("pt-BR");
 }
@@ -26,15 +66,9 @@ function formatNumber(value) {
 function formatMoney(value) {
   const number = Number(value || 0);
   if (Math.abs(number) >= 1000000) {
-    return number.toLocaleString("pt-BR", {
-      notation: "compact",
-      maximumFractionDigits: 1
-    });
+    return number.toLocaleString("pt-BR", {notation: "compact", maximumFractionDigits: 1});
   }
-
-  return number.toLocaleString("pt-BR", {
-    maximumFractionDigits: 0
-  });
+  return number.toLocaleString("pt-BR", {maximumFractionDigits: 0});
 }
 
 function formatDate(value) {
@@ -42,6 +76,51 @@ function formatDate(value) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Sem data";
   return date.toLocaleDateString("pt-BR");
+}
+
+function canManageSelectedGroup() {
+  return !!state.selectedGroup?.canManage;
+}
+
+function visibleTabs() {
+  return tabDefs.filter((tab) => {
+    if (tab.needsOps) return !!state.permissions.canUseOps;
+    if (tab.needsAnnouncements) return !!state.permissions.canUseAnnouncements;
+    if (tab.needsGroup) return state.groups.some((group) => group.canManage);
+    return true;
+  });
+}
+
+async function api(path, options = {}) {
+  const headers = {
+    ...(options.headers || {})
+  };
+
+  if (options.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  if (options.mutate) {
+    headers["X-CSRF-Token"] = state.csrfToken || "";
+  }
+
+  const response = await fetch(path, {
+    method: options.method || "GET",
+    credentials: "include",
+    headers,
+    body: options.body !== undefined ? JSON.stringify(options.body) : undefined
+  });
+
+  if (!response.ok) {
+    let message = "Nao foi possivel concluir.";
+    try {
+      const data = await response.json();
+      message = data.error || message;
+    } catch {}
+    throw new Error(message);
+  }
+
+  return response.status === 204 ? null : response.json();
 }
 
 async function loginWithToken(token) {
@@ -60,95 +139,607 @@ async function loginWithToken(token) {
 }
 
 async function loadMe() {
-  const response = await fetch("/auth/me", {credentials: "include"});
+  const data = await api("/auth/me");
+  state.csrfToken = data.csrfToken;
+  state.user = data.user;
+  state.permissions = data.permissions || {};
+  state.groups = data.groups || [];
+  state.ops = data.ops || {};
 
-  if (!response.ok) {
-    throw new Error("Voce nao esta logado. Gere outro link no WhatsApp com /painel.");
+  if (!state.selectedGroupId || !state.groups.some((group) => group.groupId === state.selectedGroupId)) {
+    const manageable = state.groups.find((group) => group.canManage);
+    state.selectedGroupId = manageable?.groupId || state.groups[0]?.groupId || null;
   }
 
-  return response.json();
+  state.selectedGroup = state.groups.find((group) => group.groupId === state.selectedGroupId) || null;
 }
 
-function setChip(id, active, onText, offText) {
-  const el = document.getElementById(id);
-  el.textContent = active ? onText : offText;
-  el.className = `chip ${active ? "ok" : "off"}`;
+async function loadGroupDetails(force = false) {
+  if (!state.selectedGroupId || !canManageSelectedGroup()) {
+    state.groupDetails = null;
+    return null;
+  }
+
+  if (!force && state.groupDetails?.group?.groupId === state.selectedGroupId) return state.groupDetails;
+
+  setStatus("Sincronizando...");
+  state.groupDetails = await api(`/auth/panel/groups/${encodeURIComponent(state.selectedGroupId)}`);
+  setStatus("Online", "ok");
+  return state.groupDetails;
 }
 
-function render(data) {
-  const { user, groups } = data;
+function renderShell() {
+  document.getElementById("roleBadge").textContent = state.user.roleLabel || "Usuario";
+  document.getElementById("roleBadge").className = `role-badge ${state.user.role || "user"}`;
+
+  tabsEl.innerHTML = visibleTabs().map((tab) => `
+    <button class="tab-button ${state.activeTab === tab.id ? "active" : ""}" data-tab="${tab.id}" type="button">
+      ${escapeHtml(tab.label)}
+    </button>
+  `).join("");
+
+  for (const [id, view] of Object.entries(views)) {
+    view.classList.toggle("active", id === state.activeTab);
+  }
+}
+
+function renderProfile() {
+  const user = state.user;
   const vipActive = user.isVip && (!user.vencimentoVip || new Date(user.vencimentoVip).getTime() >= Date.now());
-  currentGroups = groups;
+  const managedCount = state.groups.filter((group) => group.canManage).length;
 
-  document.getElementById("userName").textContent = user.name || "Sem nome";
-  document.getElementById("userLid").textContent = user.userLid;
-  document.getElementById("money").textContent = formatMoney(user.dinheiro);
-  document.getElementById("level").textContent = formatNumber(user.level);
-  document.getElementById("xp").textContent = `${formatNumber(user.xp)} / ${formatNumber(user.proximolevel)}`;
-  document.getElementById("commands").textContent = formatNumber(user.cmdCount);
-  document.getElementById("downloads").textContent = formatNumber(user.downloads);
-  document.getElementById("stickers").textContent = formatNumber(user.figurinhas);
+  views.profile.innerHTML = `
+    <section class="identity-panel liquid">
+      <div>
+        <p class="eyebrow">Sessao reconhecida</p>
+        <h2>${escapeHtml(user.name || "Sem nome")}</h2>
+        <p class="muted">${escapeHtml(user.userLid)}</p>
+      </div>
+      <div class="identity-stack">
+        <span class="vip ${vipActive ? "ok" : "off"}">${vipActive ? `VIP ate ${formatDate(user.vencimentoVip)}` : "VIP inativo"}</span>
+        <span class="role-chip ${escapeHtml(user.role)}">${escapeHtml(user.roleLabel || "Usuario")}</span>
+      </div>
+    </section>
 
-  const vipEl = document.getElementById("vipState");
-  vipEl.textContent = vipActive ? `VIP ate ${formatDate(user.vencimentoVip)}` : "VIP inativo";
-  vipEl.className = `vip ${vipActive ? "ok" : "off"}`;
+    <section class="metrics-grid">
+      ${metric("Dinheiro", formatMoney(user.dinheiro), true)}
+      ${metric("Level", formatNumber(user.level))}
+      ${metric("XP", `${formatNumber(user.xp)} / ${formatNumber(user.proximolevel)}`)}
+      ${metric("Comandos", formatNumber(user.cmdCount))}
+      ${metric("Downloads", formatNumber(user.downloads))}
+      ${metric("Figurinhas", formatNumber(user.figurinhas))}
+    </section>
 
-  setChip("discordChip", user.discordConnected, user.discordName ? `Discord: ${user.discordName}` : "Discord conectado", "Discord off");
-  setChip("spotifyChip", user.spotifyConnected, "Spotify conectado", "Spotify off");
+    <section class="profile-split">
+      <div class="liquid quiet-panel">
+        <p class="eyebrow">Acesso</p>
+        <h3>${managedCount ? `${managedCount} grupos gerenciaveis` : "Conta comum"}</h3>
+        <p class="muted">${accessCopy(user.role, managedCount)}</p>
+      </div>
+      <div class="liquid quiet-panel">
+        <p class="eyebrow">Perfil</p>
+        <h3>${formatNumber(user.waifus)} waifus</h3>
+        <p class="muted">${formatNumber(user.conquistas)} conquistas registradas.</p>
+      </div>
+    </section>
+  `;
+}
 
+function metric(label, value, accent = false) {
+  return `
+    <article class="metric liquid ${accent ? "accent" : ""}">
+      <span>${escapeHtml(label)}</span>
+      <strong>${escapeHtml(value)}</strong>
+    </article>
+  `;
+}
+
+function accessCopy(role, managedCount) {
+  if (role === "owner") return "Acesso total da Yuki. Acoes sensiveis ficam auditadas.";
+  if (role === "subowner") return "Staff operacional. Acoes ficam abaixo dos donos reais.";
+  if (managedCount) return "Admin de grupo com acoes liberadas nos grupos onde voce ainda e admin.";
+  return "Seu painel mostra dados pessoais e status nos grupos.";
+}
+
+function renderGroups() {
+  const managed = state.groups.filter((group) => group.canManage).length;
+  views.groups.innerHTML = `
+    <section class="workspace-grid">
+      <div class="liquid group-list-panel">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Contexto</p>
+            <h2>Grupos</h2>
+          </div>
+          <span class="count">${managed}/${state.groups.length}</span>
+        </div>
+        <input id="groupSearch" class="search-input" type="search" placeholder="Buscar grupo">
+        <div id="groupList" class="group-list"></div>
+      </div>
+      <div class="liquid group-focus">
+        ${renderSelectedGroupSummary()}
+      </div>
+    </section>
+  `;
+
+  renderGroupList("");
+}
+
+function renderGroupList(query) {
+  const list = document.getElementById("groupList");
+  if (!list) return;
+
+  const normalized = String(query || "").toLowerCase();
+  const groups = state.groups.filter((group) => `${group.name} ${group.groupId}`.toLowerCase().includes(normalized));
+
+  list.innerHTML = groups.length ? groups.map((group) => `
+    <button class="group-row ${group.groupId === state.selectedGroupId ? "active" : ""}" data-group-id="${escapeHtml(group.groupId)}" type="button">
+      <span>
+        <strong>${escapeHtml(group.name)}</strong>
+        <small>${escapeHtml(group.groupId)}</small>
+      </span>
+      <em class="${group.canManage ? "ok-text" : ""}">${group.canManage ? "gerenciar" : group.muted ? "mutado" : "ver"}</em>
+    </button>
+  `).join("") : '<p class="empty">Nenhum grupo encontrado.</p>';
+}
+
+function renderSelectedGroupSummary() {
+  const group = state.selectedGroup;
+  if (!group) {
+    return `
+      <p class="eyebrow">Selecionado</p>
+      <h2>Nenhum grupo</h2>
+      <p class="muted">Use a Yuki em um grupo para ele aparecer aqui.</p>
+    `;
+  }
+
+  return `
+    <p class="eyebrow">Selecionado</p>
+    <h2>${escapeHtml(group.name)}</h2>
+    <p class="muted break">${escapeHtml(group.groupId)}</p>
+    <div class="status-matrix">
+      <span>${group.canManage ? "Gerenciavel" : "Leitura"}</span>
+      <span>${group.muted ? `Mutado (${group.muteAttempts})` : "Nao mutado"}</span>
+      <span>${group.advertencias ? `${group.advertencias} adv` : "Sem adv"}</span>
+      <span>${formatNumber(group.messages)} msgs</span>
+      <span>${formatNumber(group.commands)} cmds</span>
+      <span>Aluguel ${formatDate(group.aluguel)}</span>
+    </div>
+    ${group.canManage ? '<button class="primary-button" data-tab="config" type="button">Abrir controles</button>' : '<p class="muted">Sem permissao administrativa ao vivo para esse grupo.</p>'}
+  `;
+}
+
+function renderConfig() {
+  const detail = state.groupDetails;
+  if (!state.selectedGroup || !canManageSelectedGroup()) {
+    views.config.innerHTML = emptyPanel("Config", "Selecione um grupo gerenciavel.");
+    return;
+  }
+
+  if (!detail) {
+    views.config.innerHTML = loadingPanel("Config");
+    return;
+  }
+
+  const config = detail.group.configs;
+  views.config.innerHTML = `
+    <section class="liquid control-surface">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Grupo</p>
+          <h2>${escapeHtml(detail.group.name)}</h2>
+        </div>
+        <span class="count">${formatNumber(detail.group.participantCount)} membros</span>
+      </div>
+
+      <form id="configForm">
+        <div class="toggle-grid">
+          ${toggleControl("welcome", "Welcome", config.welcome)}
+          ${toggleControl("antilink", "Anti-link", config.antlink)}
+          ${toggleControl("brincadeira", "Brincadeira", config.cmdFun)}
+          ${toggleControl("autoReply", "Auto resposta", config.autoReply)}
+          ${toggleControl("autoDownload", "Auto download", config.autoDownload)}
+          ${toggleControl("antiTotag", "Anti marcar", config.antiTotag)}
+          ${toggleControl("events", "Eventos", config.events)}
+        </div>
+
+        <div class="prefix-row">
+          <label>
+            <span>Prefixo</span>
+            <input id="prefixInput" maxlength="1" value="${escapeHtml(config.prefixo || "/")}">
+          </label>
+          <button class="primary-button" type="submit">Salvar config</button>
+        </div>
+      </form>
+      <p id="configMessage" class="form-message"></p>
+    </section>
+  `;
+}
+
+function toggleControl(name, label, checked) {
+  return `
+    <label class="liquid-toggle">
+      <input type="checkbox" name="${escapeHtml(name)}" ${checked ? "checked" : ""}>
+      <span>${escapeHtml(label)}</span>
+      <em>${checked ? "On" : "Off"}</em>
+    </label>
+  `;
+}
+
+function renderModeration() {
+  const detail = state.groupDetails;
+  if (!state.selectedGroup || !canManageSelectedGroup()) {
+    views.moderation.innerHTML = emptyPanel("Moderacao", "Selecione um grupo gerenciavel.");
+    return;
+  }
+
+  if (!detail) {
+    views.moderation.innerHTML = loadingPanel("Moderacao");
+    return;
+  }
+
+  views.moderation.innerHTML = `
+    <section class="workspace-grid moderation-layout">
+      <div class="liquid member-panel">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Membros</p>
+            <h2>${escapeHtml(detail.group.name)}</h2>
+          </div>
+          <span class="count">${detail.members.length}</span>
+        </div>
+        <input id="memberSearch" class="search-input" type="search" placeholder="Buscar membro">
+        <div id="memberList" class="member-list"></div>
+      </div>
+      <div class="liquid quiet-panel">
+        <p class="eyebrow">Grupo</p>
+        <h3>Acoes rapidas</h3>
+        <div class="action-stack">
+          <button class="ghost-button" data-group-action="open" type="button">Abrir grupo</button>
+          <button class="ghost-button" data-group-action="close" type="button">Fechar grupo</button>
+        </div>
+        <p class="muted">Todas as acoes consultam o WhatsApp na hora e ficam no log.</p>
+      </div>
+    </section>
+  `;
+
+  renderMemberList("");
+}
+
+function renderMemberList(query) {
+  const list = document.getElementById("memberList");
+  if (!list || !state.groupDetails) return;
+
+  const normalized = String(query || "").toLowerCase();
+  const members = state.groupDetails.members
+    .filter((member) => `${member.name} ${member.userLid}`.toLowerCase().includes(normalized))
+    .sort((a, b) => Number(b.isAdmin) - Number(a.isAdmin) || b.messages - a.messages);
+
+  list.innerHTML = members.length ? members.map((member) => `
+    <article class="member-row">
+      <div>
+        <strong>${escapeHtml(member.name)}</strong>
+        <small>${escapeHtml(member.userLid)}</small>
+        <span class="member-badges">
+          <em>${escapeHtml(member.role)}</em>
+          ${member.muted ? "<em>mutado</em>" : ""}
+          ${member.advertencias ? `<em>${member.advertencias} adv</em>` : ""}
+          <em>${formatNumber(member.messages)} msgs</em>
+        </span>
+      </div>
+      <div class="member-actions">
+        <button data-member-action="${member.muted ? "unmute" : "mute"}" data-target="${escapeHtml(member.userLid)}" type="button">${member.muted ? "Desmutar" : "Mutar"}</button>
+        <button data-member-action="warn" data-target="${escapeHtml(member.userLid)}" type="button">Adv</button>
+        <button data-member-action="unwarn" data-target="${escapeHtml(member.userLid)}" type="button">Rm adv</button>
+        <button data-member-action="promote" data-target="${escapeHtml(member.userLid)}" type="button">Promover</button>
+        <button data-member-action="demote" data-target="${escapeHtml(member.userLid)}" type="button">Rebaixar</button>
+        <button class="danger-link" data-member-action="ban" data-target="${escapeHtml(member.userLid)}" type="button">Ban</button>
+      </div>
+    </article>
+  `).join("") : '<p class="empty">Nenhum membro encontrado.</p>';
+}
+
+function renderOps() {
+  const logs = state.ops.recentLogs || [];
+  const subowners = state.ops.subowners || [];
+
+  views.ops.innerHTML = `
+    <section class="ops-grid">
+      <div class="liquid ops-hero">
+        <p class="eyebrow">Yuki ops</p>
+        <h2>${formatNumber(state.ops.activeGroups || 0)} grupos ativos</h2>
+        <p class="muted">${formatNumber(state.ops.totalGroups || 0)} grupos cadastrados. ${subowners.length} subdonos registrados.</p>
+      </div>
+      <div class="liquid quiet-panel">
+        <p class="eyebrow">Staff</p>
+        <div class="staff-list">
+          ${subowners.length ? subowners.map((owner) => `<span>${escapeHtml(owner.userLid)}</span>`).join("") : "<span>Nenhum subdono.</span>"}
+        </div>
+      </div>
+    </section>
+    <section class="liquid log-panel">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Auditoria</p>
+          <h2>Ultimas acoes</h2>
+        </div>
+      </div>
+      <div class="log-list">
+        ${logs.length ? logs.map(renderLog).join("") : '<p class="empty">Nenhuma acao registrada ainda.</p>'}
+      </div>
+    </section>
+  `;
+}
+
+function renderLog(log) {
+  return `
+    <article class="log-row">
+      <span class="${log.status === "success" ? "ok-text" : "bad-text"}">${escapeHtml(log.status)}</span>
+      <strong>${escapeHtml(log.action)}</strong>
+      <small>${escapeHtml(log.groupId || "global")}</small>
+      <small>${formatDate(log.createdAt)}</small>
+    </article>
+  `;
+}
+
+function renderAnnouncements() {
+  views.announcements.innerHTML = `
+    <section class="announcement-grid">
+      <form id="announcementForm" class="liquid announcement-editor">
+        <p class="eyebrow">Broadcast</p>
+        <h2>Anuncio global</h2>
+        <textarea id="announcementText" maxlength="2000" placeholder="Mensagem para os grupos ativos"></textarea>
+        <div class="announcement-controls">
+          <label><span>Limite</span><input id="announcementLimit" type="number" min="1" max="25" value="15"></label>
+          <label><span>Delay min</span><input id="announcementMinDelay" type="number" min="10" value="20"></label>
+          <label><span>Delay max</span><input id="announcementMaxDelay" type="number" min="10" value="20"></label>
+        </div>
+        <button class="primary-button" type="submit">Gerar preview</button>
+        <p id="announcementMessage" class="form-message"></p>
+      </form>
+      <div id="announcementPreview" class="liquid announcement-preview">
+        ${renderAnnouncementPreview()}
+      </div>
+    </section>
+  `;
+}
+
+function renderAnnouncementPreview() {
+  const preview = state.announcementPreview;
+  if (!preview) {
+    return `
+      <p class="eyebrow">Preview</p>
+      <h2>Nenhum rascunho</h2>
+      <p class="muted">O envio global so libera depois do preview.</p>
+    `;
+  }
+
+  return `
+    <p class="eyebrow">Preview</p>
+    <h2>${preview.selected}/${preview.total} grupos</h2>
+    <pre>${escapeHtml(preview.message)}</pre>
+    <div class="preview-groups">
+      ${preview.groups.slice(0, 8).map((group) => `<span>${escapeHtml(group.name)}</span>`).join("")}
+    </div>
+    <button class="danger-button" id="confirmAnnouncement" type="button">Confirmar envio</button>
+  `;
+}
+
+function loadingPanel(title) {
+  return `
+    <section class="liquid empty-panel">
+      <p class="eyebrow">${escapeHtml(title)}</p>
+      <h2>Sincronizando</h2>
+      <p class="muted">Consultando o WhatsApp em tempo real.</p>
+    </section>
+  `;
+}
+
+function emptyPanel(title, text) {
+  return `
+    <section class="liquid empty-panel">
+      <p class="eyebrow">${escapeHtml(title)}</p>
+      <h2>Nada selecionado</h2>
+      <p class="muted">${escapeHtml(text)}</p>
+    </section>
+  `;
+}
+
+function renderAll() {
+  renderShell();
+  renderProfile();
   renderGroups();
-  errorEl.classList.add("hidden");
+  renderConfig();
+  renderModeration();
+  renderOps();
+  renderAnnouncements();
+  clearError();
   contentEl.classList.remove("hidden");
   setStatus("Online", "ok");
 }
 
-function matchesFilter(group) {
-  if (currentFilter === "muted") return group.muted;
-  if (currentFilter === "warned") return group.advertencias > 0;
-  if (currentFilter === "admin") return group.isAdminRegistered;
-  return true;
-}
+async function switchTab(tabId) {
+  if (!visibleTabs().some((tab) => tab.id === tabId)) return;
+  state.activeTab = tabId;
 
-function renderGroups() {
-  const groupsEl = document.getElementById("groups");
-  const query = searchEl.value.trim().toLowerCase();
-  const visibleGroups = currentGroups.filter((group) => {
-    const haystack = `${group.name} ${group.groupId}`.toLowerCase();
-    return matchesFilter(group) && (!query || haystack.includes(query));
-  });
-
-  document.getElementById("groupCount").textContent = `${visibleGroups.length} de ${currentGroups.length}`;
-
-  if (!visibleGroups.length) {
-    groupsEl.innerHTML = '<p class="empty">Nenhum grupo nesse filtro.</p>';
-    return;
+  if (["config", "moderation"].includes(tabId) && canManageSelectedGroup()) {
+    renderAll();
+    await loadGroupDetails();
   }
 
-  groupsEl.innerHTML = visibleGroups.map((group) => `
-    <article class="group">
-      <div>
-        <h3>${escapeHtml(group.name)}</h3>
-        <p class="muted">${escapeHtml(group.groupId)}</p>
-      </div>
-      <div class="group-meta">
-        ${group.isAdminRegistered ? '<span class="badge ok">admin registrado</span>' : '<span class="badge">sem admin salvo</span>'}
-        ${group.muted ? `<span class="badge bad">mutado (${group.muteAttempts})</span>` : '<span class="badge ok">nao mutado</span>'}
-        ${group.advertencias ? `<span class="badge warn">${group.advertencias} adv</span>` : '<span class="badge ok">sem adv</span>'}
-        <span class="badge">${formatNumber(group.messages)} msgs</span>
-        <span class="badge">${formatNumber(group.commands)} cmds</span>
-      </div>
-    </article>
-  `).join("");
+  renderAll();
 }
 
-function escapeHtml(value) {
-  return String(value || "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#039;");
+async function selectGroup(groupId) {
+  state.selectedGroupId = groupId;
+  state.selectedGroup = state.groups.find((group) => group.groupId === groupId) || null;
+  state.groupDetails = null;
+  if (state.selectedGroup?.canManage && ["config", "moderation"].includes(state.activeTab)) {
+    await loadGroupDetails(true);
+  }
+  renderAll();
 }
+
+async function saveConfig(event) {
+  event.preventDefault();
+  if (!state.groupDetails) return;
+
+  const form = event.currentTarget;
+  const body = {
+    prefixo: form.querySelector("#prefixInput").value,
+    welcome: form.querySelector('[name="welcome"]').checked,
+    antilink: form.querySelector('[name="antilink"]').checked,
+    brincadeira: form.querySelector('[name="brincadeira"]').checked,
+    autoReply: form.querySelector('[name="autoReply"]').checked,
+    autoDownload: form.querySelector('[name="autoDownload"]').checked,
+    antiTotag: form.querySelector('[name="antiTotag"]').checked,
+    events: form.querySelector('[name="events"]').checked
+  };
+
+  const message = document.getElementById("configMessage");
+  message.textContent = "Salvando...";
+  await api(`/auth/panel/groups/${encodeURIComponent(state.selectedGroupId)}/config`, {
+    method: "PATCH",
+    mutate: true,
+    body
+  });
+  state.groupDetails = null;
+  await loadMe();
+  await loadGroupDetails(true);
+  renderAll();
+}
+
+async function runAction(action, targetLid = null) {
+  const label = targetLid ? `${action} em ${targetLid}` : action;
+  const ok = await confirmAction("Confirmar acao", `Executar ${label}?`);
+  if (!ok) return;
+
+  setStatus("Executando...");
+  const result = await api(`/auth/panel/groups/${encodeURIComponent(state.selectedGroupId)}/actions`, {
+    method: "POST",
+    mutate: true,
+    body: {action, targetLid}
+  });
+
+  await loadMe();
+  await loadGroupDetails(true);
+  renderAll();
+  setStatus(result.message || "Feito", "ok");
+}
+
+function confirmAction(title, text) {
+  return new Promise((resolve) => {
+    const template = document.getElementById("confirmTemplate");
+    const node = template.content.firstElementChild.cloneNode(true);
+    node.querySelector("#confirmTitle").textContent = title;
+    node.querySelector("#confirmText").textContent = text;
+    document.body.appendChild(node);
+
+    node.querySelector("#confirmCancel").addEventListener("click", () => {
+      node.remove();
+      resolve(false);
+    });
+
+    node.querySelector("#confirmOk").addEventListener("click", () => {
+      node.remove();
+      resolve(true);
+    });
+  });
+}
+
+async function createAnnouncement(event) {
+  event.preventDefault();
+  const message = document.getElementById("announcementMessage");
+  message.textContent = "Gerando preview...";
+
+  const preview = await api("/auth/panel/announcements/preview", {
+    method: "POST",
+    mutate: true,
+    body: {
+      text: document.getElementById("announcementText").value,
+      limit: Number(document.getElementById("announcementLimit").value),
+      minDelay: Number(document.getElementById("announcementMinDelay").value),
+      maxDelay: Number(document.getElementById("announcementMaxDelay").value)
+    }
+  });
+
+  state.announcementPreview = preview.preview;
+  renderAll();
+}
+
+async function confirmAnnouncement() {
+  if (!state.announcementPreview) return;
+  const ok = await confirmAction("Enviar anuncio", `Enviar para ${state.announcementPreview.selected} grupos?`);
+  if (!ok) return;
+
+  await api("/auth/panel/announcements/confirm", {
+    method: "POST",
+    mutate: true,
+    body: {previewId: state.announcementPreview.id}
+  });
+
+  state.announcementPreview = null;
+  await loadMe();
+  renderAll();
+  setStatus("Anuncio iniciado", "ok");
+}
+
+document.addEventListener("click", async (event) => {
+  try {
+    const tabButton = event.target.closest("[data-tab]");
+    if (tabButton) {
+      await switchTab(tabButton.dataset.tab);
+      return;
+    }
+
+    const groupButton = event.target.closest("[data-group-id]");
+    if (groupButton) {
+      await selectGroup(groupButton.dataset.groupId);
+      return;
+    }
+
+    const memberButton = event.target.closest("[data-member-action]");
+    if (memberButton) {
+      await runAction(memberButton.dataset.memberAction, memberButton.dataset.target);
+      return;
+    }
+
+    const groupActionButton = event.target.closest("[data-group-action]");
+    if (groupActionButton) {
+      await runAction(groupActionButton.dataset.groupAction);
+      return;
+    }
+
+    if (event.target.id === "confirmAnnouncement") {
+      await confirmAnnouncement();
+    }
+  } catch (err) {
+    setStatus("Erro", "error");
+    errorEl.textContent = err.message || "Falha na acao.";
+    errorEl.classList.remove("hidden");
+  }
+});
+
+document.addEventListener("input", (event) => {
+  if (event.target.id === "groupSearch") renderGroupList(event.target.value);
+  if (event.target.id === "memberSearch") renderMemberList(event.target.value);
+});
+
+document.addEventListener("submit", async (event) => {
+  try {
+    if (event.target.id === "configForm") {
+      await saveConfig(event);
+    }
+
+    if (event.target.id === "announcementForm") {
+      await createAnnouncement(event);
+    }
+  } catch (err) {
+    setStatus("Erro", "error");
+    const message = event.target.querySelector(".form-message");
+    if (message) message.textContent = err.message || "Falha ao salvar.";
+  }
+});
 
 async function boot() {
   try {
@@ -161,21 +752,11 @@ async function boot() {
     }
 
     setStatus("Carregando...");
-    const data = await loadMe();
-    render(data);
+    await loadMe();
+    renderAll();
   } catch (err) {
     showError(err.message || "Nao foi possivel abrir o painel.");
   }
-}
-
-searchEl.addEventListener("input", renderGroups);
-
-for (const segment of segmentEls) {
-  segment.addEventListener("click", () => {
-    currentFilter = segment.dataset.filter;
-    for (const item of segmentEls) item.classList.toggle("active", item === segment);
-    renderGroups();
-  });
 }
 
 boot();

--- a/src/backend/public/painel/index.html
+++ b/src/backend/public/painel/index.html
@@ -12,7 +12,7 @@
   <div class="atmosphere" aria-hidden="true"></div>
 
   <main class="app">
-    <section class="topbar glass">
+    <header class="topbar liquid">
       <div class="brand">
         <span class="brand-mark">Y</span>
         <div>
@@ -20,88 +20,39 @@
           <h1>Painel</h1>
         </div>
       </div>
-      <div id="status" class="status">Carregando...</div>
-    </section>
+      <div class="top-meta">
+        <span id="roleBadge" class="role-badge">Usuario</span>
+        <span id="status" class="status">Carregando...</span>
+      </div>
+    </header>
 
     <section id="error" class="notice hidden"></section>
 
-    <section id="content" class="workspace hidden">
-      <section class="identity glass">
-        <div class="identity-copy">
-          <p class="eyebrow">Sessao reconhecida</p>
-          <h2 id="userName">-</h2>
-          <p id="userLid" class="muted">-</p>
-        </div>
-        <div class="identity-side">
-          <span class="orbital-label">Yuki</span>
-          <div class="vip" id="vipState">VIP</div>
-        </div>
-      </section>
+    <section id="content" class="shell hidden">
+      <nav id="tabs" class="tab-rail liquid" aria-label="Areas do painel"></nav>
 
-      <section class="metrics" aria-label="Resumo do usuario">
-        <article class="metric glass accent">
-          <span>Dinheiro</span>
-          <strong id="money">0</strong>
-        </article>
-        <article class="metric glass">
-          <span>Level</span>
-          <strong id="level">0</strong>
-        </article>
-        <article class="metric glass">
-          <span>XP</span>
-          <strong id="xp">0</strong>
-        </article>
-        <article class="metric glass">
-          <span>Comandos</span>
-          <strong id="commands">0</strong>
-        </article>
-        <article class="metric glass">
-          <span>Downloads</span>
-          <strong id="downloads">0</strong>
-        </article>
-        <article class="metric glass">
-          <span>Figurinhas</span>
-          <strong id="stickers">0</strong>
-        </article>
-      </section>
-
-      <section class="connections glass">
-        <div>
-          <p class="eyebrow">Vinculos</p>
-          <h2>Conexoes</h2>
-        </div>
-        <div class="chips">
-          <span id="discordChip" class="chip">Discord</span>
-          <span id="spotifyChip" class="chip">Spotify</span>
-        </div>
-      </section>
-
-      <section class="groups-panel glass">
-        <div class="panel-head">
-          <div>
-            <p class="eyebrow">Situacao por grupo</p>
-            <h2>Grupos</h2>
-          </div>
-          <span id="groupCount" class="muted">0</span>
-        </div>
-
-        <div class="tools">
-          <label class="search">
-            <span>Buscar</span>
-            <input id="groupSearch" type="search" autocomplete="off" placeholder="Nome ou ID do grupo">
-          </label>
-          <div class="segments" aria-label="Filtro dos grupos">
-            <button class="segment active" data-filter="all" type="button">Todos</button>
-            <button class="segment" data-filter="muted" type="button">Mutado</button>
-            <button class="segment" data-filter="warned" type="button">Adv</button>
-            <button class="segment" data-filter="admin" type="button">Admin</button>
-          </div>
-        </div>
-
-        <div id="groups" class="groups"></div>
-      </section>
+      <section id="viewProfile" class="view active"></section>
+      <section id="viewGroups" class="view"></section>
+      <section id="viewConfig" class="view"></section>
+      <section id="viewModeration" class="view"></section>
+      <section id="viewOps" class="view"></section>
+      <section id="viewAnnouncements" class="view"></section>
     </section>
   </main>
+
+  <template id="confirmTemplate">
+    <div class="modal-backdrop">
+      <section class="confirm-modal liquid" role="dialog" aria-modal="true">
+        <p class="eyebrow">Confirmacao</p>
+        <h2 id="confirmTitle">Confirmar acao</h2>
+        <p id="confirmText" class="muted"></p>
+        <div class="modal-actions">
+          <button id="confirmCancel" class="ghost-button" type="button">Cancelar</button>
+          <button id="confirmOk" class="danger-button" type="button">Confirmar</button>
+        </div>
+      </section>
+    </div>
+  </template>
 
   <script type="importmap">
     {

--- a/src/backend/public/painel/styles.css
+++ b/src/backend/public/painel/styles.css
@@ -1,18 +1,18 @@
 :root {
   color-scheme: dark;
-  --bg: #080b0d;
-  --glass: rgba(18, 24, 29, .58);
-  --glass-strong: rgba(24, 31, 37, .78);
-  --line: rgba(193, 225, 255, .14);
-  --line-strong: rgba(193, 225, 255, .26);
-  --text: #f4f8fb;
-  --muted: #8fb0c5;
-  --soft: #c8ddeb;
-  --accent: #78d7ff;
-  --accent-2: #67f0b2;
-  --warn: #ffd66b;
-  --bad: #ff7d8a;
-  --shadow: 0 24px 80px rgba(0, 0, 0, .42);
+  --bg: #02090c;
+  --surface: rgba(8, 20, 25, .58);
+  --surface-strong: rgba(12, 28, 35, .74);
+  --line: rgba(150, 221, 255, .18);
+  --line-hot: rgba(117, 223, 255, .48);
+  --text: #f2f8fb;
+  --muted: #93b4c7;
+  --soft: #4f7284;
+  --accent: #76dcff;
+  --ok: #65f0ae;
+  --warn: #ffd166;
+  --bad: #ff7488;
+  --shadow: 0 24px 90px rgba(0, 0, 0, .42);
   --radius: 8px;
 }
 
@@ -21,32 +21,37 @@
 }
 
 html {
-  min-height: 100%;
+  min-width: 320px;
   background: var(--bg);
 }
 
 body {
+  min-height: 100svh;
   margin: 0;
-  min-height: 100vh;
+  overflow-x: hidden;
   color: var(--text);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  overflow-x: hidden;
+  letter-spacing: 0;
+  background:
+    radial-gradient(circle at 18% 0%, rgba(92, 207, 255, .16), transparent 34rem),
+    radial-gradient(circle at 92% 72%, rgba(80, 255, 174, .12), transparent 26rem),
+    linear-gradient(145deg, #02090c 0%, #071115 52%, #02080b 100%);
 }
 
-body::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  z-index: -3;
-  background:
-    radial-gradient(circle at 50% -20%, rgba(120, 215, 255, .16), transparent 35%),
-    linear-gradient(135deg, #071013 0%, #101417 45%, #080b0d 100%);
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  color: inherit;
 }
 
 #yukiScene {
   position: fixed;
   inset: 0;
-  z-index: -2;
+  z-index: 0;
   width: 100%;
   height: 100%;
   pointer-events: none;
@@ -55,369 +60,573 @@ body::before {
 .atmosphere {
   position: fixed;
   inset: 0;
-  z-index: -1;
+  z-index: 1;
   pointer-events: none;
   background:
-    linear-gradient(180deg, rgba(8, 11, 13, .1), rgba(8, 11, 13, .9) 72%),
-    repeating-linear-gradient(90deg, rgba(255, 255, 255, .025) 0 1px, transparent 1px 84px);
-  mask-image: linear-gradient(180deg, #000 0%, rgba(0, 0, 0, .92) 58%, rgba(0, 0, 0, .72) 100%);
+    linear-gradient(90deg, rgba(2, 9, 12, .96), rgba(2, 9, 12, .72) 43%, rgba(2, 9, 12, .24)),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, .025) 0 1px, transparent 1px 140px),
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, .02) 0 1px, transparent 1px 120px);
 }
 
 .app {
-  width: min(1180px, calc(100% - 32px));
+  position: relative;
+  z-index: 2;
+  width: min(1220px, calc(100% - 40px));
   margin: 0 auto;
-  padding: 24px 0 56px;
+  padding: 24px 0 42px;
 }
 
-.glass {
+.liquid {
+  position: relative;
+  overflow: hidden;
   border: 1px solid var(--line);
-  background: var(--glass);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(22px) saturate(140%);
-  -webkit-backdrop-filter: blur(22px) saturate(140%);
   border-radius: var(--radius);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, .075), rgba(255, 255, 255, .026)),
+    var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(22px) saturate(145%);
+}
+
+.liquid::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, .16), transparent 28%),
+    radial-gradient(circle at 20% 0%, rgba(118, 220, 255, .18), transparent 18rem);
+  opacity: .72;
 }
 
 .topbar,
-.identity,
-.connections,
-.panel-head,
-.tools {
+.brand,
+.top-meta,
+.section-head,
+.profile-split,
+.prefix-row,
+.announcement-controls,
+.modal-actions {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 16px;
 }
 
 .topbar {
-  padding: 16px;
-  margin-bottom: 16px;
+  min-height: 104px;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 20px;
   animation: rise .5s ease both;
 }
 
 .brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
+  gap: 14px;
 }
 
 .brand-mark {
   display: grid;
+  width: 52px;
+  height: 52px;
   place-items: center;
-  width: 42px;
-  height: 42px;
-  border: 1px solid rgba(120, 215, 255, .42);
+  flex: 0 0 auto;
+  border: 1px solid rgba(118, 220, 255, .55);
   border-radius: 50%;
-  color: var(--accent);
-  background: rgba(120, 215, 255, .08);
+  color: #8be4ff;
   font-weight: 800;
-}
-
-.eyebrow,
-.label,
-.muted {
-  color: var(--muted);
+  font-size: 22px;
+  background: rgba(19, 51, 62, .72);
 }
 
 .eyebrow {
-  margin: 0 0 4px;
+  margin: 0 0 5px;
+  color: #9dc3d5;
   font-size: 11px;
+  font-weight: 800;
+  letter-spacing: .12em;
   text-transform: uppercase;
-  letter-spacing: .08em;
 }
 
 h1,
 h2,
 h3,
 p {
-  margin: 0;
+  margin-top: 0;
 }
 
 h1 {
-  font-size: clamp(30px, 5vw, 54px);
-  line-height: .95;
+  margin-bottom: 0;
+  font-size: clamp(42px, 6vw, 76px);
+  line-height: .9;
 }
 
 h2 {
-  font-size: clamp(19px, 2.5vw, 26px);
-  line-height: 1.1;
+  margin-bottom: 8px;
+  font-size: clamp(30px, 4vw, 58px);
+  line-height: .95;
+}
+
+h3 {
+  margin-bottom: 8px;
+  font-size: 24px;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.break {
+  overflow-wrap: anywhere;
+}
+
+.top-meta {
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .status,
+.role-badge,
 .vip,
-.chip,
-.badge,
-.segment {
+.role-chip,
+.count {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 0 14px;
   border: 1px solid var(--line);
   border-radius: 999px;
-  padding: 8px 11px;
-  font-size: 13px;
   color: var(--muted);
-  white-space: nowrap;
-  background: rgba(8, 11, 13, .28);
+  background: rgba(6, 18, 23, .54);
 }
 
 .status.ok,
-.chip.ok,
+.role-badge.owner,
+.role-badge.subowner,
 .vip.ok,
-.badge.ok {
-  color: var(--accent-2);
-  border-color: rgba(103, 240, 178, .48);
-  background: rgba(103, 240, 178, .07);
+.role-chip.owner,
+.role-chip.subowner,
+.ok-text {
+  color: var(--ok);
+  border-color: rgba(101, 240, 174, .48);
 }
 
 .status.error,
-.chip.off,
 .vip.off,
-.badge.bad {
+.bad-text {
   color: var(--bad);
-  border-color: rgba(255, 125, 138, .5);
-  background: rgba(255, 125, 138, .07);
+  border-color: rgba(255, 116, 136, .5);
+}
+
+.hidden {
+  display: none !important;
 }
 
 .notice {
-  border: 1px solid rgba(255, 125, 138, .5);
-  background: rgba(255, 125, 138, .1);
-  color: var(--text);
-  padding: 15px;
+  margin-top: 16px;
+  padding: 18px;
+  border: 1px solid rgba(255, 116, 136, .44);
   border-radius: var(--radius);
-  backdrop-filter: blur(16px);
+  color: #ffd5db;
+  background: rgba(70, 12, 22, .64);
 }
 
-.workspace {
-  display: grid;
-  gap: 16px;
+.shell {
+  margin-top: 16px;
 }
 
-.identity {
-  min-height: 168px;
-  padding: clamp(18px, 4vw, 34px);
-  background:
-    linear-gradient(115deg, rgba(24, 31, 37, .86), rgba(24, 31, 37, .46)),
-    linear-gradient(90deg, rgba(120, 215, 255, .13), transparent 52%);
-  overflow: hidden;
-  position: relative;
-  animation: rise .58s .04s ease both;
+.tab-rail {
+  position: sticky;
+  top: 10px;
+  z-index: 4;
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  overflow-x: auto;
+  scrollbar-width: none;
 }
 
-.identity::after {
-  content: "";
-  position: absolute;
-  inset: auto -12% -65% auto;
-  width: 420px;
-  aspect-ratio: 1;
-  border: 1px solid rgba(120, 215, 255, .24);
-  border-radius: 50%;
-  transform: rotateX(70deg);
+.tab-rail::-webkit-scrollbar {
+  display: none;
 }
 
-.identity-copy {
-  min-width: 0;
-  position: relative;
-  z-index: 1;
+.tab-button,
+.primary-button,
+.ghost-button,
+.danger-button,
+.member-actions button,
+.group-row,
+.danger-link {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(7, 21, 27, .72);
+  cursor: pointer;
+  transition: transform .18s ease, border-color .18s ease, background .18s ease, color .18s ease;
 }
 
-.identity-copy h2 {
-  font-size: clamp(32px, 8vw, 76px);
-  line-height: .9;
-  letter-spacing: 0;
+.tab-button {
+  min-height: 38px;
+  padding: 0 16px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.tab-button.active,
+.tab-button:hover,
+.primary-button {
+  color: #041014;
+  border-color: rgba(118, 220, 255, .8);
+  background: linear-gradient(135deg, #94e8ff, #65f0ae);
+}
+
+.primary-button,
+.ghost-button,
+.danger-button {
+  min-height: 42px;
+  padding: 0 18px;
+  font-weight: 800;
+}
+
+.ghost-button:hover,
+.member-actions button:hover {
+  transform: translateY(-1px);
+  border-color: var(--line-hot);
+}
+
+.danger-button,
+.danger-link {
+  color: #fff3f5;
+  border-color: rgba(255, 116, 136, .55);
+  background: rgba(104, 24, 38, .68);
+}
+
+.view {
+  display: none;
+  margin-top: 16px;
+  animation: rise .36s ease both;
+}
+
+.view.active {
+  display: block;
+}
+
+.identity-panel {
+  display: flex;
+  min-height: 190px;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 34px;
+}
+
+.identity-panel h2 {
   margin-bottom: 10px;
-  overflow-wrap: anywhere;
 }
 
-.identity-copy .muted {
-  color: #9bc8e5;
-  overflow-wrap: anywhere;
-}
-
-.identity-side {
+.identity-stack {
   display: grid;
+  gap: 10px;
   justify-items: end;
-  gap: 12px;
-  position: relative;
-  z-index: 1;
 }
 
-.orbital-label {
-  color: rgba(244, 248, 251, .16);
-  font-size: clamp(52px, 12vw, 128px);
-  line-height: .8;
-  font-weight: 900;
-  letter-spacing: 0;
-}
-
-.metrics {
+.metrics-grid {
   display: grid;
-  grid-template-columns: 1.3fr repeat(5, 1fr);
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 12px;
+  margin-top: 12px;
 }
 
 .metric {
-  padding: 16px;
-  min-height: 112px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  animation: rise .48s ease both;
-}
-
-.metric:nth-child(2) { animation-delay: .03s; }
-.metric:nth-child(3) { animation-delay: .06s; }
-.metric:nth-child(4) { animation-delay: .09s; }
-.metric:nth-child(5) { animation-delay: .12s; }
-.metric:nth-child(6) { animation-delay: .15s; }
-
-.metric.accent {
-  border-color: rgba(120, 215, 255, .35);
-  background: linear-gradient(145deg, rgba(120, 215, 255, .14), rgba(18, 24, 29, .62));
+  min-height: 124px;
+  padding: 18px;
 }
 
 .metric span {
+  display: block;
+  margin-bottom: 24px;
   color: var(--muted);
-  font-size: 13px;
 }
 
 .metric strong {
-  font-size: clamp(25px, 3vw, 38px);
-  line-height: 1;
+  display: block;
+  font-size: clamp(30px, 4vw, 44px);
+  line-height: .98;
+}
+
+.metric.accent {
+  border-color: rgba(118, 220, 255, .5);
+  background:
+    linear-gradient(135deg, rgba(118, 220, 255, .18), rgba(101, 240, 174, .05)),
+    var(--surface);
+}
+
+.profile-split,
+.ops-grid,
+.announcement-grid,
+.workspace-grid {
+  gap: 12px;
+  margin-top: 12px;
+  align-items: stretch;
+}
+
+.profile-split > *,
+.ops-grid > * {
+  flex: 1;
+}
+
+.quiet-panel,
+.empty-panel,
+.ops-hero,
+.announcement-preview,
+.announcement-editor,
+.control-surface,
+.member-panel,
+.group-list-panel,
+.group-focus,
+.log-panel {
+  padding: 22px;
+}
+
+.workspace-grid,
+.announcement-grid,
+.ops-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, .85fr) minmax(0, 1.35fr);
+}
+
+.moderation-layout {
+  grid-template-columns: minmax(0, 1.4fr) minmax(250px, .6fr);
+}
+
+.section-head {
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.search-input,
+.prefix-row input,
+.announcement-controls input,
+.announcement-editor textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: var(--text);
+  outline: none;
+  background: rgba(2, 10, 13, .62);
+}
+
+.search-input {
+  height: 44px;
+  padding: 0 14px;
+  margin-bottom: 12px;
+}
+
+.group-list,
+.member-list,
+.log-list,
+.staff-list,
+.preview-groups {
+  display: grid;
+  gap: 10px;
+}
+
+.group-row {
+  display: flex;
+  width: 100%;
+  min-height: 72px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  text-align: left;
+  border-radius: var(--radius);
+}
+
+.group-row strong,
+.group-row small,
+.member-row strong,
+.member-row small {
+  display: block;
+}
+
+.group-row small,
+.member-row small {
+  margin-top: 4px;
+  color: var(--muted);
   overflow-wrap: anywhere;
 }
 
-.connections,
-.groups-panel {
-  padding: 18px;
-  animation: rise .55s .08s ease both;
+.group-row.active {
+  border-color: var(--line-hot);
+  background: rgba(20, 64, 77, .62);
 }
 
-.chips {
+.status-matrix,
+.toggle-grid,
+.member-badges,
+.member-actions,
+.action-stack,
+.announcement-controls {
   display: flex;
+  gap: 8px;
   flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 10px;
 }
 
-.groups-panel {
-  display: grid;
-  gap: 16px;
+.status-matrix {
+  margin: 20px 0;
 }
 
-.tools {
-  align-items: flex-end;
-  padding-top: 2px;
-}
-
-.search {
-  display: grid;
-  gap: 7px;
-  width: min(380px, 100%);
-  color: var(--muted);
-  font-size: 12px;
-  text-transform: uppercase;
-  letter-spacing: .06em;
-}
-
-.search input {
-  width: 100%;
-  min-height: 42px;
+.status-matrix span,
+.member-badges em,
+.staff-list span,
+.preview-groups span {
+  min-height: 30px;
+  padding: 7px 10px;
   border: 1px solid var(--line);
   border-radius: 999px;
-  color: var(--text);
-  background: rgba(8, 11, 13, .42);
-  padding: 0 15px;
-  outline: none;
+  color: var(--muted);
+  background: rgba(4, 14, 18, .58);
 }
 
-.search input:focus {
-  border-color: rgba(120, 215, 255, .56);
-}
-
-.segments {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.segment {
-  cursor: pointer;
-  transition: transform .18s ease, border-color .18s ease, color .18s ease, background .18s ease;
-}
-
-.segment.active {
-  color: var(--text);
-  border-color: rgba(120, 215, 255, .55);
-  background: rgba(120, 215, 255, .13);
-}
-
-.segment:active {
-  transform: scale(.96);
-}
-
-.groups {
+.toggle-grid {
   display: grid;
-  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
-.group {
+.liquid-toggle {
+  display: flex;
+  min-height: 74px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: rgba(4, 14, 18, .55);
+}
+
+.liquid-toggle input {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--ok);
+}
+
+.liquid-toggle em {
+  color: var(--muted);
+  font-style: normal;
+}
+
+.prefix-row {
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.prefix-row label,
+.announcement-controls label {
+  display: grid;
+  flex: 1;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.prefix-row input,
+.announcement-controls input {
+  height: 42px;
+  padding: 0 12px;
+}
+
+.form-message {
+  min-height: 22px;
+  margin: 12px 0 0;
+  color: var(--muted);
+}
+
+.member-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 12px;
+  align-items: center;
   padding: 14px;
   border: 1px solid var(--line);
-  background: rgba(8, 11, 13, .35);
   border-radius: var(--radius);
-  transition: transform .2s ease, border-color .2s ease, background .2s ease;
+  background: rgba(4, 14, 18, .58);
 }
 
-.group:hover {
-  transform: translateY(-2px);
-  border-color: var(--line-strong);
-  background: rgba(15, 22, 28, .56);
-}
-
-.group h3 {
-  margin: 0 0 8px;
-  font-size: 15px;
-  line-height: 1.2;
-}
-
-.group .muted {
-  overflow-wrap: anywhere;
-}
-
-.group-meta {
-  display: flex;
-  flex-wrap: wrap;
-  align-content: center;
+.member-actions {
   justify-content: flex-end;
-  gap: 8px;
 }
 
-.badge {
-  font-size: 12px;
-  padding: 6px 8px;
+.member-actions button,
+.danger-link {
+  min-height: 32px;
+  padding: 0 10px;
+  font-size: 13px;
 }
 
-.badge.warn {
-  color: var(--warn);
-  border-color: rgba(255, 214, 107, .5);
-  background: rgba(255, 214, 107, .07);
+.announcement-editor textarea {
+  min-height: 240px;
+  resize: vertical;
+  padding: 14px;
+  line-height: 1.5;
+}
+
+.announcement-controls {
+  margin: 12px 0;
+}
+
+.announcement-preview pre {
+  max-height: 360px;
+  overflow: auto;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: var(--text);
+  white-space: pre-wrap;
+  background: rgba(2, 10, 13, .72);
+}
+
+.log-row {
+  display: grid;
+  grid-template-columns: 76px 1fr 1fr auto;
+  gap: 10px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
 }
 
 .empty {
   color: var(--muted);
-  padding: 18px 0 4px;
 }
 
-.hidden {
-  display: none;
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, .56);
+  backdrop-filter: blur(12px);
+}
+
+.confirm-modal {
+  width: min(440px, 100%);
+  padding: 24px;
+}
+
+.confirm-modal h2 {
+  font-size: 34px;
+}
+
+.modal-actions {
+  justify-content: flex-end;
+  gap: 10px;
 }
 
 @keyframes rise {
   from {
     opacity: 0;
-    transform: translateY(14px);
+    transform: translateY(10px);
   }
   to {
     opacity: 1;
@@ -425,112 +634,84 @@ h2 {
   }
 }
 
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: .01ms !important;
-    animation-iteration-count: 1 !important;
-    scroll-behavior: auto !important;
-    transition-duration: .01ms !important;
-  }
-}
-
 @media (max-width: 980px) {
-  .metrics {
+  .metrics-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .workspace-grid,
+  .announcement-grid,
+  .ops-grid,
+  .moderation-layout {
+    grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 720px) {
   .app {
-    width: min(100% - 24px, 520px);
-    padding: 14px 0 32px;
+    width: min(100% - 20px, 640px);
+    padding-top: 10px;
   }
 
   .topbar,
-  .identity,
-  .connections,
-  .panel-head,
-  .tools,
-  .group {
+  .identity-panel,
+  .profile-split,
+  .prefix-row {
     align-items: stretch;
     flex-direction: column;
-    grid-template-columns: 1fr;
   }
 
-  .topbar {
-    gap: 14px;
-  }
-
-  .status,
-  .vip {
-    text-align: center;
-    width: 100%;
-  }
-
-  .identity {
-    min-height: 158px;
-  }
-
-  .identity-side {
+  .top-meta,
+  .identity-stack {
+    justify-content: stretch;
     justify-items: stretch;
   }
 
-  .orbital-label {
-    display: none;
+  .status,
+  .role-badge,
+  .vip,
+  .role-chip {
+    justify-content: center;
+    width: 100%;
   }
 
-  .metrics {
+  .metrics-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px;
   }
 
   .metric {
-    min-height: 104px;
-    padding: 14px;
+    min-height: 136px;
   }
 
-  .metric strong {
-    font-size: 27px;
+  .toggle-grid {
+    grid-template-columns: 1fr;
   }
 
-  .chips,
-  .segments,
-  .group-meta {
+  .member-row,
+  .log-row {
+    grid-template-columns: 1fr;
+  }
+
+  .member-actions {
     justify-content: flex-start;
-  }
-
-  .groups-panel,
-  .connections {
-    padding: 16px;
-  }
-
-  .group {
-    padding: 13px;
-  }
-
-  .badge {
-    flex: 1 1 auto;
-    text-align: center;
   }
 }
 
-@media (max-width: 390px) {
-  .app {
-    width: min(100% - 18px, 520px);
+@media (max-width: 420px) {
+  .metrics-grid {
+    grid-template-columns: 1fr;
   }
 
-  .metrics {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .metric strong {
-    font-size: 24px;
+  .brand {
+    align-items: flex-start;
   }
 
   .brand-mark {
-    width: 38px;
-    height: 38px;
+    width: 48px;
+    height: 48px;
+  }
+
+  h1 {
+    font-size: 48px;
   }
 }

--- a/src/backend/routes/user.js
+++ b/src/backend/routes/user.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const isLogin = require("../middleware/isLogin");
 const user_info = require("../controllers/user/userInfo.js");
 const me = require("../controllers/user/me.js");
+const panel = require("../controllers/user/panel.js");
 const setName = require("../controllers/user/setName.js");
 const discord_auth = require('../controllers/user/discordAuth.js');
 
@@ -13,6 +14,16 @@ router.post("/login", login);
 router.get("/user", user_info);
 
 router.get("/me", isLogin, me);
+
+router.get("/panel/groups/:groupId", isLogin, panel.groupDetails);
+
+router.patch("/panel/groups/:groupId/config", isLogin, panel.updateConfig);
+
+router.post("/panel/groups/:groupId/actions", isLogin, panel.groupAction);
+
+router.post("/panel/announcements/preview", isLogin, panel.announcementPreview);
+
+router.post("/panel/announcements/confirm", isLogin, panel.announcementConfirm);
 
 router.post("/set-name", setName);
 

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -77,6 +77,11 @@ next()
   app.get("/painel", (req, res) => {
     res.sendFile(path.join(publicDir, "painel", "index.html"));
   });
+
+  app.use((req, res, next) => {
+    req.activeSock = activeSock;
+    next();
+  });
   
   app.use("/auth", userRouter);
 

--- a/src/backend/services/panelService.js
+++ b/src/backend/services/panelService.js
@@ -1,0 +1,607 @@
+const crypto = require("crypto");
+const { advertidos } = require("../../database/models/adverts");
+const { donos } = require("../../database/models/donos");
+const { grupos } = require("../../database/models/grupos");
+const { mutados } = require("../../database/models/mute");
+const { panelAudits } = require("../../database/models/panelAudit");
+const { rankativos } = require("../../database/models/rankativos");
+const { users } = require("../../database/models/users");
+const { numberBot, numberBotJid, ownerLids } = require("../../config");
+const {
+  canModerateTarget,
+  ensureGroup,
+  getOwnerLevelCached,
+  invalidateMute,
+  setMuteCache,
+  updateGroupAndCache
+} = require("../../utils/dbHelpers");
+const { normalizeUserLid } = require("../../utils/normalizeUserLid");
+
+const announcementPreviews = new Map();
+let runningAnnouncement = null;
+let lastAnnouncementAt = 0;
+
+const ANNOUNCEMENT_PREVIEW_TTL_MS = 10 * 60 * 1000;
+const ANNOUNCEMENT_COOLDOWN_MS = 30 * 60 * 1000;
+const ANNOUNCEMENT_LIMIT = 25;
+const ANNOUNCEMENT_MIN_DELAY_SECONDS = 10;
+
+function httpError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function toIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function isGroupId(value) {
+  return typeof value === "string" && value.endsWith("@g.us");
+}
+
+function decodeGroupId(value) {
+  const decoded = decodeURIComponent(String(value || ""));
+  if (!isGroupId(decoded)) throw httpError(400, "grupo invalido.");
+  return decoded;
+}
+
+function jidMatches(a, b) {
+  if (!a || !b) return false;
+  return a === b || normalizeUserLid(a) === normalizeUserLid(b);
+}
+
+function participantLid(participant) {
+  return normalizeUserLid(participant?.lid || participant?.id || "");
+}
+
+function getParticipantIds(participant) {
+  return [participant?.id, participant?.lid, participantLid(participant)].filter(Boolean);
+}
+
+function isParticipantAdmin(participant) {
+  return !!participant?.admin;
+}
+
+function findParticipant(metadata, userLid) {
+  return (metadata?.participants || []).find((participant) =>
+    getParticipantIds(participant).some((id) => jidMatches(id, userLid))
+  );
+}
+
+function isBotTarget(targetLid) {
+  return [numberBot, numberBotJid].some((botId) => botId && jidMatches(botId, targetLid));
+}
+
+async function getRole(sender) {
+  const level = await getOwnerLevelCached(sender);
+  if (level >= 2) return {name: "owner", level, label: "Dono"};
+  if (level === 1) return {name: "subowner", level, label: "Staff Yuki"};
+  return {name: "user", level: 0, label: "Usuario"};
+}
+
+async function logPanelAction(entry) {
+  try {
+    await panelAudits.create(entry);
+  } catch (err) {
+    console.error("Erro ao salvar auditoria do painel:", err);
+  }
+}
+
+async function sendGroupAuditNotice(sock, groupId, actorLid, actionLabel, targetLid) {
+  const mentions = [actorLid, targetLid].filter(Boolean);
+  const targetText = targetLid ? ` em @${targetLid.split("@")[0]}` : "";
+  await sock.sendMessage(groupId, {
+    text: `Painel Yuki: @${actorLid.split("@")[0]} executou ${actionLabel}${targetText}.`,
+    mentions
+  });
+}
+
+async function getLivePermission(sock, groupId, sender) {
+  if (!sock) throw httpError(503, "socket da yuki indisponivel.");
+
+  const [metadata, role] = await Promise.all([
+    sock.groupMetadata(groupId),
+    getRole(sender)
+  ]);
+  const actorParticipant = findParticipant(metadata, sender);
+  const isAdmin = !!actorParticipant?.admin;
+
+  await ensureGroup(groupId, metadata);
+
+  return {
+    metadata,
+    role,
+    isAdmin,
+    allowed: role.level > 0 || isAdmin
+  };
+}
+
+function compactGroup(group, extras = {}) {
+  return {
+    groupId: group.groupId,
+    name: group.grupoName || "Sem nome",
+    ownerId: group.ownerId || null,
+    aluguel: toIso(group.aluguel),
+    cmdUsados: group.cmdUsados || 0,
+    configs: {
+      events: group.configs?.events !== false,
+      welcome: group.configs?.welcome !== false,
+      antlink: !!group.configs?.antlink,
+      cmdFun: !!group.configs?.cmdFun,
+      cmdAdulto: !!group.configs?.cmdAdulto,
+      prefixo: group.configs?.prefixo || "/",
+      autoReply: group.autoReply !== false,
+      autoDownload: group.autoDownload !== false,
+      antiTotag: !!group.antiTotag
+    },
+    ...extras
+  };
+}
+
+async function buildPanelHome(sender, sock) {
+  const role = await getRole(sender);
+  const [user, mutes, adverts, ranks, allGroups, subowners] = await Promise.all([
+    users.findOne({userLid: sender}).lean(),
+    mutados.find({userLid: sender}).lean(),
+    advertidos.find({userLid: sender}).lean(),
+    rankativos.find({userLid: sender}).lean(),
+    role.level > 0 ? grupos.find({groupId: /@g\.us$/}).sort({grupoName: 1}).limit(250).lean() : Promise.resolve([]),
+    role.level > 0 ? donos.find().lean() : Promise.resolve([])
+  ]);
+
+  if (!user) throw httpError(404, "usuario nao encontrado.");
+
+  const groupIds = new Set();
+  for (const group of user.grupos || []) if (isGroupId(group?.id)) groupIds.add(group.id);
+  for (const mute of mutes) if (isGroupId(mute?.grupo)) groupIds.add(mute.grupo);
+  for (const adv of adverts) if (isGroupId(adv?.grupo)) groupIds.add(adv.grupo);
+  for (const rank of ranks) if (isGroupId(rank?.from)) groupIds.add(rank.from);
+  for (const group of allGroups) groupIds.add(group.groupId);
+
+  const groupDocs = groupIds.size
+    ? await grupos.find({groupId: {$in: Array.from(groupIds)}}).lean()
+    : [];
+
+  const savedGroups = new Map((user.grupos || []).map((group) => [group.id, group]));
+  const groupInfo = new Map(groupDocs.map((group) => [group.groupId, group]));
+  const muteInfo = new Map(mutes.map((mute) => [mute.grupo, mute]));
+  const advertInfo = new Map(adverts.map((adv) => [adv.grupo, adv]));
+  const rankInfo = new Map(ranks.map((rank) => [rank.from, rank]));
+
+  const groups = [];
+  for (const groupId of groupIds) {
+    const saved = savedGroups.get(groupId);
+    const group = groupInfo.get(groupId) || {groupId, grupoName: saved?.nome || "Sem nome"};
+    const mute = muteInfo.get(groupId);
+    const adv = advertInfo.get(groupId);
+    const rank = rankInfo.get(groupId);
+
+    let isAdminLive = false;
+    if (sock && role.level === 0) {
+      try {
+        const metadata = await sock.groupMetadata(groupId);
+        isAdminLive = !!findParticipant(metadata, sender)?.admin;
+      } catch {}
+    }
+
+    groups.push(compactGroup(group, {
+      isAdminRegistered: !!saved,
+      canManage: role.level > 0 || isAdminLive,
+      managedBy: role.level > 0 ? role.name : (isAdminLive ? "admin" : "user"),
+      muted: !!mute,
+      muteAttempts: mute?.tentativasMsg || 0,
+      advertencias: adv?.adv || 0,
+      messages: rank?.msg || 0,
+      commands: rank?.cmdUsados || 0
+    }));
+  }
+
+  const recentLogs = role.level > 0
+    ? await panelAudits.find().sort({createdAt: -1}).limit(20).lean()
+    : [];
+
+  return {
+    user: {
+      userLid: user.userLid,
+      name: user.name,
+      bio: user.bio,
+      dinheiro: user.dinheiro,
+      level: user.level,
+      xp: user.xp,
+      proximolevel: user.proximolevel,
+      isVip: !!user.isVip,
+      vencimentoVip: toIso(user.vencimentoVip),
+      registro: toIso(user.registro),
+      cmdCount: user.cmdCount,
+      downloads: user.donwloads,
+      figurinhas: user.figurinhas,
+      waifus: Array.isArray(user.waifus) ? user.waifus.length : 0,
+      conquistas: Array.isArray(user.conquistas) ? user.conquistas.length : 0,
+      role: role.name,
+      roleLabel: role.label,
+      isRealOwner: ownerLids.some((owner) => jidMatches(owner, sender))
+    },
+    permissions: {
+      canUseOps: role.level > 0,
+      canUseAnnouncements: role.level > 0,
+      canManageAnyGroup: role.level > 0
+    },
+    csrfToken: null,
+    groups,
+    ops: {
+      totalGroups: role.level > 0 ? await grupos.countDocuments({groupId: /@g\.us$/}) : null,
+      activeGroups: role.level > 0 ? await grupos.countDocuments({groupId: /@g\.us$/, aluguel: {$gt: new Date()}}) : null,
+      subowners: subowners.map((owner) => ({
+        userLid: owner.userLid,
+        desc: owner.desc,
+        data: toIso(owner.data)
+      })),
+      recentLogs: recentLogs.map((log) => ({
+        id: String(log._id),
+        actorLid: log.actorLid,
+        actorRole: log.actorRole,
+        groupId: log.groupId,
+        targetLid: log.targetLid,
+        action: log.action,
+        status: log.status,
+        message: log.message,
+        createdAt: toIso(log.createdAt)
+      }))
+    }
+  };
+}
+
+async function getGroupPanel(sock, groupId, sender) {
+  const permission = await getLivePermission(sock, groupId, sender);
+  if (!permission.allowed) throw httpError(403, "sem permissao para gerenciar esse grupo.");
+
+  const [group, mutes, adverts, ranks, logs] = await Promise.all([
+    grupos.findOne({groupId}).lean(),
+    mutados.find({grupo: groupId}).lean(),
+    advertidos.find({grupo: groupId}).lean(),
+    rankativos.find({from: groupId}).lean(),
+    panelAudits.find({groupId}).sort({createdAt: -1}).limit(30).lean()
+  ]);
+
+  const userIds = new Set();
+  for (const participant of permission.metadata.participants || []) userIds.add(participantLid(participant));
+  for (const mute of mutes) userIds.add(normalizeUserLid(mute.userLid));
+  for (const adv of adverts) userIds.add(normalizeUserLid(adv.userLid));
+  for (const rank of ranks) userIds.add(normalizeUserLid(rank.userLid));
+
+  const userDocs = await users.find({userLid: {$in: Array.from(userIds)}}).select("userLid name").lean();
+  const names = new Map(userDocs.map((user) => [user.userLid, user.name]));
+  const muteMap = new Map(mutes.map((mute) => [normalizeUserLid(mute.userLid), mute]));
+  const advMap = new Map(adverts.map((adv) => [normalizeUserLid(adv.userLid), adv]));
+  const rankMap = new Map(ranks.map((rank) => [normalizeUserLid(rank.userLid), rank]));
+
+  const members = (permission.metadata.participants || []).map((participant) => {
+    const userLid = participantLid(participant);
+    const mute = muteMap.get(userLid);
+    const adv = advMap.get(userLid);
+    const rank = rankMap.get(userLid);
+
+    return {
+      userLid,
+      jid: participant.id || participant.lid || userLid,
+      name: names.get(userLid) || userLid.split("@")[0],
+      isAdmin: isParticipantAdmin(participant),
+      isBot: isBotTarget(userLid),
+      muted: !!mute,
+      muteAttempts: mute?.tentativasMsg || 0,
+      advertencias: adv?.adv || 0,
+      messages: rank?.msg || 0,
+      commands: rank?.cmdUsados || 0,
+      roleLevel: awaitableRoleLevelPlaceholder(userLid)
+    };
+  });
+
+  const levels = await Promise.all(members.map((member) => getOwnerLevelCached(member.userLid)));
+  members.forEach((member, index) => {
+    member.roleLevel = levels[index];
+    member.role = levels[index] >= 2 ? "owner" : (levels[index] === 1 ? "subowner" : (member.isAdmin ? "admin" : "user"));
+  });
+
+  return {
+    group: compactGroup(group || {groupId, grupoName: permission.metadata.subject || "Sem nome"}, {
+      subject: permission.metadata.subject || group?.grupoName || "Sem nome",
+      participantCount: permission.metadata.participants?.length || 0,
+      actor: {
+        role: permission.role.name,
+        roleLabel: permission.role.label,
+        isAdmin: permission.isAdmin,
+        canManage: permission.allowed
+      }
+    }),
+    members,
+    logs: logs.map((log) => ({
+      id: String(log._id),
+      actorLid: log.actorLid,
+      actorRole: log.actorRole,
+      targetLid: log.targetLid,
+      action: log.action,
+      status: log.status,
+      message: log.message,
+      createdAt: toIso(log.createdAt)
+    }))
+  };
+}
+
+function awaitableRoleLevelPlaceholder() {
+  return 0;
+}
+
+async function updateGroupConfig(sock, groupId, sender, input) {
+  const permission = await getLivePermission(sock, groupId, sender);
+  if (!permission.allowed) throw httpError(403, "sem permissao para alterar esse grupo.");
+
+  const allowedKeys = {
+    welcome: "configs.welcome",
+    antilink: "configs.antlink",
+    brincadeira: "configs.cmdFun",
+    autoReply: "autoReply",
+    autoDownload: "autoDownload",
+    antiTotag: "antiTotag",
+    events: "configs.events"
+  };
+
+  const set = {};
+  if (input?.prefixo !== undefined) {
+    const prefixo = String(input.prefixo || "").trim();
+    if (!prefixo || prefixo.length > 1) throw httpError(400, "prefixo deve ter 1 caractere.");
+    set["configs.prefixo"] = prefixo;
+  }
+
+  for (const [key, path] of Object.entries(allowedKeys)) {
+    if (input?.[key] !== undefined) set[path] = !!input[key];
+  }
+
+  if (!Object.keys(set).length) throw httpError(400, "nenhuma configuracao enviada.");
+
+  const group = await updateGroupAndCache(groupId, {$set: set}, {metadata: permission.metadata});
+  const role = permission.role.name;
+  await logPanelAction({actorLid: sender, actorRole: role, groupId, action: "config", status: "success", details: set});
+  await sendGroupAuditNotice(sock, groupId, sender, "configuracao do grupo", null);
+
+  return compactGroup(group);
+}
+
+async function runGroupAction(sock, groupId, sender, input) {
+  const permission = await getLivePermission(sock, groupId, sender);
+  if (!permission.allowed) throw httpError(403, "sem permissao para agir nesse grupo.");
+
+  const action = String(input?.action || "").trim();
+  const target = input?.targetLid ? normalizeUserLid(input.targetLid) : null;
+  const targetActions = new Set(["mute", "unmute", "warn", "unwarn", "ban", "promote", "demote"]);
+  const validActions = new Set([...targetActions, "open", "close"]);
+  if (!validActions.has(action)) throw httpError(400, "acao invalida.");
+  if (targetActions.has(action) && !target) throw httpError(400, "alvo obrigatorio.");
+  if (target && isBotTarget(target) && ["mute", "ban", "demote"].includes(action)) {
+    throw httpError(400, "nao da pra usar essa acao contra a yuki.");
+  }
+  if (target && !(await canModerateTarget(sender, target))) {
+    throw httpError(403, "esse usuario esta acima de voce na hierarquia.");
+  }
+
+  const targetParticipant = target ? findParticipant(permission.metadata, target) : null;
+  const socketTarget = targetParticipant?.id || targetParticipant?.lid || target;
+
+  const role = permission.role.name;
+  try {
+    let message = "acao executada.";
+
+    if (action === "mute") {
+      const existing = await mutados.findOneAndUpdate(
+        {userLid: target, grupo: groupId},
+        {$setOnInsert: {userLid: target, grupo: groupId}},
+        {upsert: true, new: false}
+      );
+      setMuteCache(target, groupId, existing?.toObject?.() || {userLid: target, grupo: groupId, tentativasMsg: 0});
+      message = existing ? "usuario ja estava mutado." : "usuario mutado.";
+    }
+
+    if (action === "unmute") {
+      const result = await mutados.deleteOne({userLid: target, grupo: groupId});
+      invalidateMute(target, groupId);
+      message = result.deletedCount ? "usuario desmutado." : "usuario nao estava mutado.";
+    }
+
+    if (action === "warn") {
+      const adv = await advertidos.findOneAndUpdate(
+        {userLid: target, grupo: groupId},
+        {$inc: {adv: 1}},
+        {new: true, upsert: true, setDefaultsOnInsert: true}
+      );
+      message = `advertencia adicionada (${adv.adv}).`;
+      if (adv.adv >= 3) {
+        await sock.groupParticipantsUpdate(groupId, [socketTarget], "remove");
+        await advertidos.deleteOne({userLid: target, grupo: groupId});
+        message = "usuario removido por 3 advertencias.";
+      }
+    }
+
+    if (action === "unwarn") {
+      const adv = await advertidos.findOneAndUpdate(
+        {userLid: target, grupo: groupId, adv: {$gt: 0}},
+        {$inc: {adv: -1}},
+        {new: true}
+      );
+      message = adv ? `advertencia removida (${adv.adv}).` : "usuario nao tinha advertencias.";
+    }
+
+    if (action === "ban") {
+      await sock.groupParticipantsUpdate(groupId, [socketTarget], "remove");
+      message = "usuario removido do grupo.";
+    }
+
+    if (action === "promote") {
+      await sock.groupParticipantsUpdate(groupId, [socketTarget], "promote");
+      message = "usuario promovido a admin.";
+    }
+
+    if (action === "demote") {
+      await sock.groupParticipantsUpdate(groupId, [socketTarget], "demote");
+      message = "usuario rebaixado.";
+    }
+
+    if (action === "open") {
+      await sock.groupSettingUpdate(groupId, "not_announcement");
+      message = "grupo aberto.";
+    }
+
+    if (action === "close") {
+      await sock.groupSettingUpdate(groupId, "announcement");
+      message = "grupo fechado.";
+    }
+
+    await logPanelAction({actorLid: sender, actorRole: role, groupId, targetLid: target, action, status: "success", message});
+    await sendGroupAuditNotice(sock, groupId, sender, action, target);
+    return {ok: true, message};
+  } catch (err) {
+    await logPanelAction({
+      actorLid: sender,
+      actorRole: role,
+      groupId,
+      targetLid: target,
+      action,
+      status: "failed",
+      message: err?.message || String(err)
+    });
+    throw err;
+  }
+}
+
+function buildAnnouncementText(text, actorName) {
+  return `*Comunicado da Yuki*\n\n${text}\n\n_Enviado por ${actorName || "staff da Yuki"}._`;
+}
+
+async function getAnnouncementGroups(limit) {
+  const cappedLimit = Math.min(Math.max(Number(limit) || 15, 1), ANNOUNCEMENT_LIMIT);
+  const docs = await grupos
+    .find({groupId: /@g\.us$/, aluguel: {$gt: new Date()}})
+    .select("groupId grupoName configs")
+    .sort({grupoName: 1})
+    .lean();
+
+  const enabled = docs.filter((group) => group?.configs?.announcements !== false);
+  return {
+    total: enabled.length,
+    selected: enabled.slice(0, cappedLimit)
+  };
+}
+
+async function createAnnouncementPreview(sender, input) {
+  const role = await getRole(sender);
+  if (role.level === 0) throw httpError(403, "sem permissao para announcement.");
+
+  const text = String(input?.text || "").trim();
+  if (text.length < 5) throw httpError(400, "mensagem muito curta.");
+  if (text.length > 2000) throw httpError(400, "mensagem muito longa.");
+
+  const minDelay = Math.max(Number(input?.minDelay) || 20, ANNOUNCEMENT_MIN_DELAY_SECONDS);
+  const maxDelay = Math.max(Number(input?.maxDelay) || minDelay, minDelay);
+  const {total, selected} = await getAnnouncementGroups(input?.limit);
+  if (!selected.length) throw httpError(404, "nenhum grupo ativo encontrado.");
+
+  const actor = await users.findOne({userLid: sender}).select("name").lean();
+  const message = buildAnnouncementText(text, actor?.name);
+  const id = crypto.randomBytes(8).toString("hex");
+  const preview = {
+    id,
+    sender,
+    role: role.name,
+    groups: selected,
+    total,
+    message,
+    minDelay,
+    maxDelay,
+    expiresAt: Date.now() + ANNOUNCEMENT_PREVIEW_TTL_MS
+  };
+
+  announcementPreviews.set(id, preview);
+  return serializeAnnouncementPreview(preview);
+}
+
+function serializeAnnouncementPreview(preview) {
+  return {
+    id: preview.id,
+    groups: preview.groups.map((group) => ({groupId: group.groupId, name: group.grupoName || "Sem nome"})),
+    total: preview.total,
+    selected: preview.groups.length,
+    message: preview.message,
+    minDelay: preview.minDelay,
+    maxDelay: preview.maxDelay,
+    expiresAt: toIso(preview.expiresAt)
+  };
+}
+
+async function confirmAnnouncement(sock, sender, previewId) {
+  if (!sock) throw httpError(503, "socket da yuki indisponivel.");
+
+  const role = await getRole(sender);
+  if (role.level === 0) throw httpError(403, "sem permissao para announcement.");
+  if (runningAnnouncement) throw httpError(409, "ja existe announcement rodando.");
+  if (Date.now() - lastAnnouncementAt < ANNOUNCEMENT_COOLDOWN_MS) {
+    throw httpError(429, "cooldown de announcement ativo.");
+  }
+
+  const preview = announcementPreviews.get(previewId);
+  if (!preview || preview.sender !== sender || preview.expiresAt < Date.now()) {
+    announcementPreviews.delete(previewId);
+    throw httpError(404, "preview expirado ou invalido.");
+  }
+
+  announcementPreviews.delete(previewId);
+  runningAnnouncement = preview.id;
+  lastAnnouncementAt = Date.now();
+
+  runAnnouncement(sock, preview).catch((err) => {
+    console.error("Erro no announcement do painel:", err);
+  });
+
+  await logPanelAction({
+    actorLid: sender,
+    actorRole: role.name,
+    action: "announcement",
+    status: "success",
+    message: `announcement iniciado para ${preview.groups.length} grupos`
+  });
+
+  return {ok: true, id: preview.id, groups: preview.groups.length};
+}
+
+async function runAnnouncement(sock, preview) {
+  try {
+    for (const group of preview.groups) {
+      await new Promise((resolve) => setTimeout(resolve, preview.minDelay * 1000));
+      try {
+        await sock.sendMessage(group.groupId, {text: preview.message});
+      } catch (err) {
+        await logPanelAction({
+          actorLid: preview.sender,
+          actorRole: preview.role,
+          groupId: group.groupId,
+          action: "announcement",
+          status: "failed",
+          message: err?.message || String(err)
+        });
+      }
+    }
+  } finally {
+    runningAnnouncement = null;
+  }
+}
+
+module.exports = {
+  buildPanelHome,
+  confirmAnnouncement,
+  createAnnouncementPreview,
+  decodeGroupId,
+  getGroupPanel,
+  runGroupAction,
+  updateGroupConfig
+};

--- a/src/database/models/panelAudit.js
+++ b/src/database/models/panelAudit.js
@@ -1,0 +1,19 @@
+const mongoose = require("mongoose");
+
+const schema = new mongoose.Schema({
+  actorLid: {type: String, required: true, index: true},
+  actorRole: {type: String, required: true},
+  groupId: {type: String, default: null, index: true},
+  targetLid: {type: String, default: null},
+  action: {type: String, required: true, index: true},
+  status: {type: String, required: true, enum: ["success", "failed"]},
+  message: {type: String, default: null},
+  details: {type: Object, default: {}},
+  createdAt: {type: Date, default: Date.now, index: true}
+});
+
+const panelAudits = mongoose.model("panelAudit", schema);
+
+module.exports = {
+  panelAudits
+};


### PR DESCRIPTION
## Resumo
- adiciona roles de painel para usuario, admin, subdono e dono
- adiciona APIs protegidas para detalhes de grupo, configs, moderacao e anuncios
- adiciona CSRF para mutacoes do painel
- adiciona auditoria de acoes do painel
- recria a UI em liquid glass com tabs por permissao

## Testes
- node --check nos arquivos alterados
- git diff --cached --check
- teste de CSRF invalido retornando 403
- importacao dos services/controllers novos
- QA visual desktop e mobile com Playwright em servidor mock
- canvas WebGL renderizando pixels em desktop e mobile
- sem overflow horizontal no mobile
- smoke de interacao em moderacao e anuncio com endpoints mockados