### PR TITLE
feat(bolao): adiciono apostas da copa

### DIFF
--- a/src/backend/controllers/user/panel.js
+++ b/src/backend/controllers/user/panel.js
@@ -7,6 +7,15 @@ const {
   runGroupAction,
   updateGroupConfig
 } = require("../../services/panelService");
+const {
+  confirmPayout,
+  createGame,
+  createResultPreview,
+  getPanelBolaoGame,
+  listPanelBolao,
+  placeOrUpdateBet,
+  serializeGame
+} = require("../../services/bolaoService");
 
 function getSender(req) {
   const sender = req.user?.sender;
@@ -95,9 +104,94 @@ async function announcementConfirm(req, res) {
   }
 }
 
+async function bolaoHome(req, res) {
+  try {
+    const sender = getSender(req);
+    const data = await listPanelBolao(sender);
+    res.status(200).json(data);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoDetails(req, res) {
+  try {
+    const sender = getSender(req);
+    const data = await getPanelBolaoGame(sender, req.params.gameId);
+    res.status(200).json(data);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoBet(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const result = await placeOrUpdateBet({
+      gameId: req.params.gameId,
+      sender,
+      name: req.body?.name || "Sem nome",
+      homeScore: req.body?.homeScore,
+      awayScore: req.body?.awayScore,
+      amount: req.body?.amount
+    });
+    res.status(200).json(result);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoCreateGame(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const game = await createGame({
+      homeTeam: req.body?.homeTeam,
+      awayTeam: req.body?.awayTeam,
+      competition: req.body?.competition,
+      startsAt: req.body?.startsAt
+    }, sender, {skipPermission: false});
+    res.status(201).json({game: serializeGame(game)});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoResultPreview(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const game = await createResultPreview(req.params.gameId, sender, {
+      homeScore: req.body?.homeScore,
+      awayScore: req.body?.awayScore
+    });
+    res.status(200).json({game});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoPayoutConfirm(req, res) {
+  try {
+    assertCsrf(req);
+    const sender = getSender(req);
+    const game = await confirmPayout(req.params.gameId, sender);
+    res.status(200).json({game});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
 module.exports = {
   announcementConfirm,
   announcementPreview,
+  bolaoBet,
+  bolaoCreateGame,
+  bolaoDetails,
+  bolaoHome,
+  bolaoPayoutConfirm,
+  bolaoResultPreview,
   groupAction,
   groupDetails,
   listGroups,

--- a/src/backend/public/painel/app.js
+++ b/src/backend/public/painel/app.js
@@ -5,6 +5,7 @@ const tabsEl = document.getElementById("tabs");
 
 const views = {
   profile: document.getElementById("viewProfile"),
+  bolao: document.getElementById("viewBolao"),
   groups: document.getElementById("viewGroups"),
   config: document.getElementById("viewConfig"),
   moderation: document.getElementById("viewModeration"),
@@ -22,11 +23,22 @@ const state = {
   selectedGroupId: null,
   selectedGroup: null,
   groupDetails: null,
-  announcementPreview: null
+  announcementPreview: null,
+  bolao: {
+    loading: false,
+    canManage: false,
+    balance: 0,
+    stats: {},
+    games: [],
+    selectedGameId: null,
+    selectedGame: null,
+    details: null
+  }
 };
 
 const tabDefs = [
   {id: "profile", label: "Perfil"},
+  {id: "bolao", label: "Bolao"},
   {id: "groups", label: "Grupos"},
   {id: "config", label: "Config", needsGroup: true},
   {id: "moderation", label: "Moderacao", needsGroup: true},
@@ -78,6 +90,25 @@ function formatDate(value) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Sem data";
   return date.toLocaleDateString("pt-BR");
+}
+
+function formatDateTime(value) {
+  if (!value) return "Sem data";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Sem data";
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function toDateTimeLocal(value) {
+  const date = value ? new Date(value) : new Date(Date.now() + 3 * 60 * 60 * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  const offset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
 function canManageSelectedGroup() {
@@ -215,6 +246,57 @@ async function loadGroupDetails(force = false) {
   return state.groupDetails;
 }
 
+function setSelectedBolaoGame(gameId) {
+  const games = state.bolao.games || [];
+  if (gameId && games.some((game) => game.id === gameId || game.code === gameId)) {
+    const game = games.find((item) => item.id === gameId || item.code === gameId);
+    state.bolao.selectedGameId = game.id;
+    state.bolao.selectedGame = game;
+    return;
+  }
+
+  if (!state.bolao.selectedGameId || !games.some((game) => game.id === state.bolao.selectedGameId)) {
+    const open = games.find((game) => game.status === "open");
+    const pending = games.find((game) => ["scheduled", "closed", "awaiting_result", "result_pending_confirmation"].includes(game.status));
+    state.bolao.selectedGameId = (open || pending || games[0])?.id || null;
+  }
+
+  state.bolao.selectedGame = games.find((game) => game.id === state.bolao.selectedGameId) || null;
+}
+
+async function loadBolaoSummary(preferredGameId = null) {
+  state.bolao.loading = true;
+  const data = await api("/auth/panel/bolao");
+  state.bolao.canManage = !!data.canManage;
+  state.bolao.balance = data.balance || 0;
+  state.bolao.stats = data.stats || {};
+  state.bolao.games = data.games || [];
+  setSelectedBolaoGame(preferredGameId);
+  state.bolao.loading = false;
+
+  if (state.bolao.selectedGameId) {
+    await loadBolaoDetails(state.bolao.selectedGameId);
+  }
+}
+
+async function loadBolaoDetails(gameId = state.bolao.selectedGameId) {
+  if (!gameId) {
+    state.bolao.details = null;
+    return null;
+  }
+
+  state.bolao.details = await api(`/auth/panel/bolao/${encodeURIComponent(gameId)}`);
+  const detailGame = state.bolao.details?.game;
+  if (detailGame) {
+    const index = state.bolao.games.findIndex((game) => game.id === detailGame.id);
+    if (index >= 0) state.bolao.games[index] = detailGame;
+    else state.bolao.games.unshift(detailGame);
+    state.bolao.selectedGameId = detailGame.id;
+    state.bolao.selectedGame = detailGame;
+  }
+  return state.bolao.details;
+}
+
 function renderShell() {
   document.getElementById("roleBadge").textContent = state.user.roleLabel || "Usuario";
   document.getElementById("roleBadge").className = `role-badge ${state.user.role || "user"}`;
@@ -286,6 +368,215 @@ function accessCopy(role, managedCount) {
   if (role === "subowner") return "Staff operacional. Acoes ficam abaixo dos donos reais.";
   if (managedCount) return "Admin de grupo com acoes liberadas nos grupos onde voce ainda e admin.";
   return "Seu painel mostra dados pessoais e status nos grupos.";
+}
+
+function renderBolao() {
+  if (state.bolao.loading && !state.bolao.games.length) {
+    views.bolao.innerHTML = loadingPanel("Bolao");
+    return;
+  }
+
+  const games = state.bolao.games || [];
+  const selected = state.bolao.selectedGame;
+  const detail = state.bolao.details;
+
+  views.bolao.innerHTML = `
+    <section class="bolao-hero liquid">
+      <div class="pitch-lines" aria-hidden="true"></div>
+      <div class="bolao-title">
+        <p class="eyebrow">Moedas em campo</p>
+        <h2>Bolao</h2>
+        <p class="muted">Placar exato, aposta editavel e pagamento travado por confirmacao.</p>
+      </div>
+      <div class="bolao-kpis">
+        ${bolaoKpi("Saldo", formatMoney(state.bolao.balance))}
+        ${bolaoKpi("Abertos", formatNumber(state.bolao.stats.openGames))}
+        ${bolaoKpi("Em jogo", formatNumber(state.bolao.stats.pendingResults))}
+      </div>
+    </section>
+
+    <section class="bolao-layout">
+      <aside class="liquid bolao-rail">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Rodadas</p>
+            <h3>Jogos</h3>
+          </div>
+          <span class="count">${games.length}</span>
+        </div>
+        <div class="bolao-game-list">
+          ${games.length ? games.map(renderBolaoGameButton).join("") : '<p class="empty">Nenhum jogo cadastrado ainda.</p>'}
+        </div>
+      </aside>
+
+      <div class="bolao-main">
+        ${selected ? renderBolaoFocus(selected, detail) : renderBolaoEmpty()}
+        ${state.bolao.canManage ? renderBolaoAdmin(selected) : ""}
+      </div>
+    </section>
+  `;
+}
+
+function bolaoKpi(label, value) {
+  return `
+    <span class="bolao-kpi">
+      <small>${escapeHtml(label)}</small>
+      <strong>${escapeHtml(value)}</strong>
+    </span>
+  `;
+}
+
+function bolaoStatusClass(status) {
+  if (status === "open") return "live";
+  if (["paid", "refunded"].includes(status)) return "done";
+  if (["closed", "awaiting_result", "result_pending_confirmation", "paying"].includes(status)) return "locked";
+  if (status === "cancelled") return "bad";
+  return "idle";
+}
+
+function renderBolaoGameButton(game) {
+  return `
+    <button class="bolao-game ${game.id === state.bolao.selectedGameId ? "active" : ""}" data-bolao-game="${escapeHtml(game.id)}" type="button">
+      <span>
+        <strong>${escapeHtml(game.title)}</strong>
+        <small>${escapeHtml(game.code)} · ${formatDateTime(game.startsAt)}</small>
+      </span>
+      <em class="${bolaoStatusClass(game.status)}">${escapeHtml(game.statusLabel)}</em>
+    </button>
+  `;
+}
+
+function renderBolaoFocus(game, detail) {
+  const userBet = detail?.game?.userBet || game.userBet;
+  const bets = detail?.bets || [];
+  const leaderboard = detail?.leaderboard || [];
+
+  return `
+    <section class="liquid bolao-ticket">
+      <div class="ticket-glow" aria-hidden="true"></div>
+      <div class="bolao-match-head">
+        <div>
+          <p class="eyebrow">${escapeHtml(game.competition || "Copa")}</p>
+          <h2>${escapeHtml(game.homeTeam)} <span>x</span> ${escapeHtml(game.awayTeam)}</h2>
+        </div>
+        <span class="bolao-status ${bolaoStatusClass(game.status)}">${escapeHtml(game.statusLabel)}</span>
+      </div>
+
+      <div class="match-strip">
+        <span><strong>${formatDateTime(game.startsAt)}</strong><small>Jogo</small></span>
+        <span><strong>${formatDateTime(game.bettingClosesAt)}</strong><small>Fecha</small></span>
+        <span><strong>${formatMoney(game.pool || 0)}</strong><small>Pool</small></span>
+        <span><strong>${formatNumber(game.bets || 0)}</strong><small>Apostas</small></span>
+      </div>
+
+      ${renderBolaoBetForm(game, userBet)}
+      ${renderBolaoBetLists(game, bets, leaderboard)}
+    </section>
+  `;
+}
+
+function renderBolaoBetForm(game, userBet) {
+  const disabled = !game.canBet;
+  const homeValue = userBet?.homeScore ?? "";
+  const awayValue = userBet?.awayScore ?? "";
+  const stakeValue = userBet?.stake || 100;
+
+  return `
+    <form id="bolaoBetForm" class="bolao-bet ${disabled ? "disabled" : ""}" data-game-id="${escapeHtml(game.id)}">
+      <div>
+        <p class="eyebrow">${userBet ? "Seu bilhete" : "Nova aposta"}</p>
+        <h3>${userBet ? `${escapeHtml(userBet.score)} · ${formatMoney(userBet.stake)} moedas` : "Cravar placar"}</h3>
+        <p class="muted">${disabled ? "Apostas fechadas para esta partida." : "Voce pode editar ate a janela fechar."}</p>
+      </div>
+      <div class="score-editor">
+        <label><span>${escapeHtml(game.homeTeam)}</span><input id="bolaoHomeScore" type="number" min="0" max="30" value="${escapeHtml(homeValue)}" ${disabled ? "disabled" : ""}></label>
+        <strong>x</strong>
+        <label><span>${escapeHtml(game.awayTeam)}</span><input id="bolaoAwayScore" type="number" min="0" max="30" value="${escapeHtml(awayValue)}" ${disabled ? "disabled" : ""}></label>
+        <label><span>Moedas</span><input id="bolaoStake" type="number" min="100" step="1" value="${escapeHtml(stakeValue)}" ${disabled ? "disabled" : ""}></label>
+        <button class="primary-button" type="submit" ${disabled ? "disabled" : ""}>${userBet ? "Atualizar" : "Apostar"}</button>
+      </div>
+      <p id="bolaoBetMessage" class="form-message"></p>
+    </form>
+  `;
+}
+
+function renderBolaoBetLists(game, bets, leaderboard) {
+  const preview = game.payoutPreview || {};
+  const previewHtml = ["result_pending_confirmation", "paying", "paid", "refunded"].includes(game.status) ? `
+    <div class="bolao-preview">
+      <p class="eyebrow">Preview</p>
+      <h3>${preview.winnerCount ? `${preview.winnerCount} ganhadores` : "Reembolso geral"}</h3>
+      <p class="muted">Pool ${formatMoney(preview.pool)} · pagamento ${formatMoney(preview.totalPayout || preview.pool)}</p>
+    </div>
+  ` : "";
+
+  const list = leaderboard.length ? leaderboard : bets;
+  const rows = list.length ? list.slice(0, 10).map((item) => `
+    <article class="bolao-row">
+      <span>${escapeHtml(item.name || "Sem nome")}</span>
+      <strong>${escapeHtml(item.score || "oculto")}</strong>
+      <em>${formatMoney(item.paidAmount || item.stake || 0)}</em>
+    </article>
+  `).join("") : '<p class="empty">As apostas aparecem aqui quando houver dados liberados.</p>';
+
+  return `
+    <div class="bolao-bottom">
+      ${previewHtml}
+      <div class="bolao-table">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">${leaderboard.length ? "Resultado" : "Movimento"}</p>
+            <h3>${leaderboard.length ? "Ranking" : "Apostas"}</h3>
+          </div>
+        </div>
+        ${rows}
+      </div>
+    </div>
+  `;
+}
+
+function renderBolaoAdmin(selected) {
+  const resultDisabled = !selected || !["closed", "awaiting_result", "result_pending_confirmation"].includes(selected.status);
+
+  return `
+    <section class="bolao-admin">
+      <form id="bolaoCreateForm" class="liquid bolao-admin-panel">
+        <p class="eyebrow">Dono</p>
+        <h3>Criar jogo</h3>
+        <div class="bolao-admin-grid">
+          <label><span>Mandante</span><input id="bolaoCreateHome" required placeholder="Brasil"></label>
+          <label><span>Visitante</span><input id="bolaoCreateAway" required placeholder="Argentina"></label>
+          <label><span>Data</span><input id="bolaoCreateStart" type="datetime-local" required value="${escapeHtml(toDateTimeLocal())}"></label>
+          <label><span>Competicao</span><input id="bolaoCreateCompetition" value="Copa do Mundo"></label>
+        </div>
+        <button class="primary-button" type="submit">Agendar</button>
+        <p id="bolaoCreateMessage" class="form-message"></p>
+      </form>
+
+      <form id="bolaoResultForm" class="liquid bolao-admin-panel ${resultDisabled ? "disabled" : ""}" data-game-id="${escapeHtml(selected?.id || "")}">
+        <p class="eyebrow">Resultado</p>
+        <h3>${selected ? escapeHtml(selected.title) : "Selecione um jogo"}</h3>
+        <div class="score-editor compact">
+          <label><span>Casa</span><input id="bolaoResultHome" type="number" min="0" max="30" ${resultDisabled ? "disabled" : ""}></label>
+          <strong>x</strong>
+          <label><span>Fora</span><input id="bolaoResultAway" type="number" min="0" max="30" ${resultDisabled ? "disabled" : ""}></label>
+          <button class="ghost-button" type="submit" ${resultDisabled ? "disabled" : ""}>Preview</button>
+        </div>
+        <button id="bolaoConfirmPayout" class="danger-button" type="button" data-game-id="${escapeHtml(selected?.id || "")}" ${selected?.status === "result_pending_confirmation" ? "" : "disabled"}>Confirmar pagamento</button>
+        <p id="bolaoResultMessage" class="form-message"></p>
+      </form>
+    </section>
+  `;
+}
+
+function renderBolaoEmpty() {
+  return `
+    <section class="liquid empty-panel">
+      <p class="eyebrow">Bolao</p>
+      <h2>Nenhum jogo</h2>
+      <p class="muted">Quando a Yuki abrir uma rodada, ela aparece aqui.</p>
+    </section>
+  `;
 }
 
 function renderGroups() {
@@ -388,6 +679,7 @@ function renderConfig() {
           ${toggleControl("autoDownload", "Auto download", config.autoDownload)}
           ${toggleControl("antiTotag", "Anti marcar", config.antiTotag)}
           ${toggleControl("events", "Eventos", config.events)}
+          ${toggleControl("bolao", "Bolao", config.bolao)}
         </div>
 
         <div class="prefix-row">
@@ -595,6 +887,7 @@ function emptyPanel(title, text) {
 function renderAll() {
   renderShell();
   renderProfile();
+  renderBolao();
   renderGroups();
   renderConfig();
   renderModeration();
@@ -608,6 +901,11 @@ function renderAll() {
 async function switchTab(tabId) {
   if (!visibleTabs().some((tab) => tab.id === tabId)) return;
   state.activeTab = tabId;
+
+  if (tabId === "bolao") {
+    renderAll();
+    await loadBolaoSummary();
+  }
 
   if (["config", "moderation"].includes(tabId) && canManageSelectedGroup()) {
     renderAll();
@@ -627,6 +925,14 @@ async function selectGroup(groupId) {
   renderAll();
 }
 
+async function selectBolaoGame(gameId) {
+  setSelectedBolaoGame(gameId);
+  state.bolao.details = null;
+  renderAll();
+  await loadBolaoDetails(state.bolao.selectedGameId);
+  renderAll();
+}
+
 async function saveConfig(event) {
   event.preventDefault();
   if (!state.groupDetails) return;
@@ -640,7 +946,8 @@ async function saveConfig(event) {
     autoReply: form.querySelector('[name="autoReply"]').checked,
     autoDownload: form.querySelector('[name="autoDownload"]').checked,
     antiTotag: form.querySelector('[name="antiTotag"]').checked,
-    events: form.querySelector('[name="events"]').checked
+    events: form.querySelector('[name="events"]').checked,
+    bolao: form.querySelector('[name="bolao"]').checked
   };
 
   const message = document.getElementById("configMessage");
@@ -731,6 +1038,88 @@ async function confirmAnnouncement() {
   setStatus("Anuncio iniciado", "ok");
 }
 
+async function submitBolaoBet(event) {
+  event.preventDefault();
+  const form = event.target;
+  const gameId = form.dataset.gameId;
+  const message = document.getElementById("bolaoBetMessage");
+  if (message) message.textContent = "Registrando...";
+
+  await api(`/auth/panel/bolao/${encodeURIComponent(gameId)}/bets`, {
+    method: "POST",
+    mutate: true,
+    body: {
+      name: state.user?.name || "Sem nome",
+      homeScore: Number(document.getElementById("bolaoHomeScore").value),
+      awayScore: Number(document.getElementById("bolaoAwayScore").value),
+      amount: Number(document.getElementById("bolaoStake").value)
+    }
+  });
+
+  await loadBolaoSummary(gameId);
+  renderAll();
+  setStatus("Aposta salva", "ok");
+}
+
+async function submitBolaoCreate(event) {
+  event.preventDefault();
+  const message = document.getElementById("bolaoCreateMessage");
+  if (message) message.textContent = "Agendando...";
+
+  const created = await api("/auth/panel/bolao/games", {
+    method: "POST",
+    mutate: true,
+    body: {
+      homeTeam: document.getElementById("bolaoCreateHome").value,
+      awayTeam: document.getElementById("bolaoCreateAway").value,
+      startsAt: document.getElementById("bolaoCreateStart").value.replace("T", " "),
+      competition: document.getElementById("bolaoCreateCompetition").value
+    }
+  });
+
+  await loadBolaoSummary(created.game?.id);
+  renderAll();
+  setStatus("Jogo agendado", "ok");
+}
+
+async function submitBolaoResult(event) {
+  event.preventDefault();
+  const form = event.target;
+  const gameId = form.dataset.gameId;
+  if (!gameId) return;
+
+  const message = document.getElementById("bolaoResultMessage");
+  if (message) message.textContent = "Calculando...";
+
+  await api(`/auth/panel/bolao/${encodeURIComponent(gameId)}/result`, {
+    method: "POST",
+    mutate: true,
+    body: {
+      homeScore: Number(document.getElementById("bolaoResultHome").value),
+      awayScore: Number(document.getElementById("bolaoResultAway").value)
+    }
+  });
+
+  await loadBolaoSummary(gameId);
+  renderAll();
+  setStatus("Preview pronto", "ok");
+}
+
+async function confirmBolaoPayout(gameId) {
+  const ok = await confirmAction("Pagar bolao", "Confirmar pagamento ou reembolso deste jogo?");
+  if (!ok) return;
+
+  await api(`/auth/panel/bolao/${encodeURIComponent(gameId)}/payout`, {
+    method: "POST",
+    mutate: true,
+    body: {}
+  });
+
+  await loadBolaoSummary(gameId);
+  renderAll();
+  setStatus("Pagamento confirmado", "ok");
+}
+
 document.addEventListener("click", async (event) => {
   try {
     const tabButton = event.target.closest("[data-tab]");
@@ -742,6 +1131,12 @@ document.addEventListener("click", async (event) => {
     const groupButton = event.target.closest("[data-group-id]");
     if (groupButton) {
       await selectGroup(groupButton.dataset.groupId);
+      return;
+    }
+
+    const bolaoGameButton = event.target.closest("[data-bolao-game]");
+    if (bolaoGameButton) {
+      await selectBolaoGame(bolaoGameButton.dataset.bolaoGame);
       return;
     }
 
@@ -759,6 +1154,10 @@ document.addEventListener("click", async (event) => {
 
     if (event.target.id === "confirmAnnouncement") {
       await confirmAnnouncement();
+    }
+
+    if (event.target.id === "bolaoConfirmPayout") {
+      await confirmBolaoPayout(event.target.dataset.gameId);
     }
   } catch (err) {
     setStatus("Erro", "error");
@@ -781,6 +1180,18 @@ document.addEventListener("submit", async (event) => {
     if (event.target.id === "announcementForm") {
       await createAnnouncement(event);
     }
+
+    if (event.target.id === "bolaoBetForm") {
+      await submitBolaoBet(event);
+    }
+
+    if (event.target.id === "bolaoCreateForm") {
+      await submitBolaoCreate(event);
+    }
+
+    if (event.target.id === "bolaoResultForm") {
+      await submitBolaoResult(event);
+    }
   } catch (err) {
     setStatus("Erro", "error");
     const message = event.target.querySelector(".form-message");
@@ -792,6 +1203,8 @@ async function boot() {
   try {
     const params = new URLSearchParams(window.location.search);
     const token = params.get("token");
+    const bolaoHash = window.location.hash.match(/^#bolao\/([^?#]+)/);
+    const bolaoGameId = bolaoHash ? decodeURIComponent(bolaoHash[1]) : null;
 
     if (token) {
       setStatus("Entrando...");
@@ -800,7 +1213,18 @@ async function boot() {
 
     setStatus("Carregando...");
     await loadMe();
+    if (bolaoGameId) state.activeTab = "bolao";
+    if (state.activeTab === "bolao") {
+      await loadBolaoSummary(bolaoGameId);
+    }
     renderAll();
+    if (state.activeTab !== "bolao") {
+      loadBolaoSummary()
+        .then(() => renderAll())
+        .catch((err) => {
+          console.warn("Nao foi possivel carregar bolao:", err);
+        });
+    }
     loadManageableGroups()
       .then(() => renderAll())
       .catch((err) => {

--- a/src/backend/public/painel/index.html
+++ b/src/backend/public/painel/index.html
@@ -32,6 +32,7 @@
       <nav id="tabs" class="tab-rail liquid" aria-label="Areas do painel"></nav>
 
       <section id="viewProfile" class="view active"></section>
+      <section id="viewBolao" class="view"></section>
       <section id="viewGroups" class="view"></section>
       <section id="viewConfig" class="view"></section>
       <section id="viewModeration" class="view"></section>

--- a/src/backend/public/painel/styles.css
+++ b/src/backend/public/painel/styles.css
@@ -595,6 +595,344 @@ h3 {
   border-bottom: 1px solid rgba(255, 255, 255, .08);
 }
 
+.primary-button:disabled,
+.ghost-button:disabled,
+.danger-button:disabled,
+button:disabled {
+  cursor: not-allowed;
+  opacity: .52;
+}
+
+.bolao-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, .9fr);
+  gap: 22px;
+  min-height: 250px;
+  margin-bottom: 12px;
+  padding: 32px;
+  isolation: isolate;
+  background:
+    linear-gradient(120deg, rgba(5, 42, 32, .78), rgba(9, 25, 40, .64) 52%, rgba(25, 36, 10, .58)),
+    var(--surface);
+}
+
+.pitch-lines {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: .36;
+  background:
+    linear-gradient(90deg, transparent 0 47%, rgba(255, 255, 255, .28) 47% 47.35%, transparent 47.35%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, .12) 0 1px, transparent 1px 92px),
+    repeating-linear-gradient(0deg, rgba(255, 255, 255, .08) 0 1px, transparent 1px 70px);
+  transform: skewY(-4deg) scale(1.08);
+}
+
+.bolao-title,
+.bolao-kpis,
+.bolao-match-head,
+.bolao-bet,
+.bolao-bottom,
+.bolao-admin-panel > * {
+  position: relative;
+  z-index: 1;
+}
+
+.bolao-title {
+  align-self: end;
+}
+
+.bolao-title h2 {
+  margin-bottom: 12px;
+  color: #f8fffb;
+  text-shadow: 0 18px 48px rgba(0, 0, 0, .42);
+}
+
+.bolao-kpis {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  align-self: end;
+}
+
+.bolao-kpi {
+  min-height: 112px;
+  padding: 16px;
+  border: 1px solid rgba(242, 255, 150, .22);
+  border-radius: var(--radius);
+  background: rgba(4, 17, 16, .48);
+}
+
+.bolao-kpi small,
+.bolao-kpi strong {
+  display: block;
+}
+
+.bolao-kpi small {
+  color: #c7d8c7;
+}
+
+.bolao-kpi strong {
+  margin-top: 22px;
+  font-size: clamp(28px, 4vw, 42px);
+  line-height: 1;
+}
+
+.bolao-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, .78fr) minmax(0, 1.35fr);
+  gap: 12px;
+}
+
+.bolao-rail,
+.bolao-ticket,
+.bolao-admin-panel {
+  padding: 22px;
+}
+
+.bolao-game-list {
+  display: grid;
+  gap: 10px;
+}
+
+.bolao-game {
+  display: flex;
+  width: 100%;
+  min-height: 78px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 14px;
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: var(--radius);
+  text-align: left;
+  background: rgba(4, 14, 18, .56);
+}
+
+.bolao-game.active {
+  border-color: rgba(255, 221, 87, .54);
+  background:
+    linear-gradient(120deg, rgba(21, 85, 52, .54), rgba(16, 45, 63, .5)),
+    rgba(4, 14, 18, .56);
+}
+
+.bolao-game strong,
+.bolao-game small {
+  display: block;
+}
+
+.bolao-game small {
+  margin-top: 5px;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.bolao-game em,
+.bolao-status {
+  flex: 0 0 auto;
+  min-height: 30px;
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-size: 12px;
+  font-style: normal;
+  white-space: nowrap;
+  background: rgba(2, 10, 13, .58);
+}
+
+.bolao-game em.live,
+.bolao-status.live {
+  color: #7dffc0;
+  border-color: rgba(125, 255, 192, .48);
+}
+
+.bolao-game em.locked,
+.bolao-status.locked {
+  color: #ffe26e;
+  border-color: rgba(255, 226, 110, .5);
+}
+
+.bolao-game em.done,
+.bolao-status.done {
+  color: #8bd7ff;
+  border-color: rgba(139, 215, 255, .5);
+}
+
+.bolao-game em.bad,
+.bolao-status.bad {
+  color: var(--bad);
+  border-color: rgba(255, 116, 136, .5);
+}
+
+.bolao-main {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.bolao-ticket {
+  isolation: isolate;
+  min-height: 460px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, .085), rgba(255, 255, 255, .028)),
+    linear-gradient(160deg, rgba(5, 31, 35, .76), rgba(8, 18, 26, .78) 52%, rgba(27, 36, 11, .48));
+}
+
+.ticket-glow {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: .46;
+  background:
+    linear-gradient(110deg, rgba(74, 255, 151, .18), transparent 36%),
+    linear-gradient(290deg, rgba(255, 219, 70, .16), transparent 42%);
+}
+
+.bolao-match-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  margin-bottom: 20px;
+}
+
+.bolao-match-head h2 {
+  max-width: 780px;
+  margin-bottom: 0;
+}
+
+.bolao-match-head h2 span {
+  color: #ffe26e;
+}
+
+.match-strip {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.match-strip span {
+  min-height: 82px;
+  padding: 13px;
+  border: 1px solid rgba(255, 255, 255, .13);
+  border-radius: var(--radius);
+  background: rgba(2, 10, 13, .46);
+}
+
+.match-strip strong,
+.match-strip small {
+  display: block;
+}
+
+.match-strip small {
+  margin-top: 12px;
+  color: var(--muted);
+}
+
+.bolao-bet {
+  display: grid;
+  grid-template-columns: minmax(220px, .7fr) minmax(0, 1.3fr);
+  gap: 16px;
+  align-items: end;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, .14);
+  border-radius: var(--radius);
+  background: rgba(3, 14, 17, .58);
+}
+
+.bolao-bet.disabled,
+.bolao-admin-panel.disabled {
+  opacity: .72;
+}
+
+.score-editor {
+  display: grid;
+  grid-template-columns: minmax(90px, 1fr) auto minmax(90px, 1fr) minmax(100px, .85fr) auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.score-editor.compact {
+  grid-template-columns: minmax(80px, 1fr) auto minmax(80px, 1fr) auto;
+}
+
+.score-editor label,
+.bolao-admin-grid label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.score-editor input,
+.bolao-admin-grid input {
+  width: 100%;
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0 12px;
+  color: var(--text);
+  outline: none;
+  background: rgba(1, 8, 10, .7);
+}
+
+.score-editor strong {
+  align-self: center;
+  color: #ffe26e;
+  font-size: 24px;
+}
+
+.bolao-bottom {
+  display: grid;
+  grid-template-columns: minmax(220px, .7fr) minmax(0, 1.3fr);
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.bolao-preview,
+.bolao-table {
+  padding: 16px;
+  border: 1px solid rgba(255, 255, 255, .12);
+  border-radius: var(--radius);
+  background: rgba(2, 10, 13, .48);
+}
+
+.bolao-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 82px 96px;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
+}
+
+.bolao-row span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bolao-row em {
+  color: #ffe26e;
+  font-style: normal;
+  text-align: right;
+}
+
+.bolao-admin {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(300px, .8fr);
+  gap: 12px;
+}
+
+.bolao-admin-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
 .empty {
   color: var(--muted);
 }
@@ -653,8 +991,27 @@ h3 {
   .workspace-grid,
   .announcement-grid,
   .ops-grid,
-  .moderation-layout {
+  .moderation-layout,
+  .bolao-hero,
+  .bolao-layout,
+  .bolao-bet,
+  .bolao-bottom,
+  .bolao-admin {
     grid-template-columns: 1fr;
+  }
+
+  .bolao-kpis,
+  .match-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .score-editor,
+  .score-editor.compact {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .score-editor strong {
+    display: none;
   }
 }
 
@@ -702,9 +1059,32 @@ h3 {
     grid-template-columns: 1fr;
   }
 
-  .member-row,
-  .log-row {
+  .bolao-hero,
+  .bolao-ticket,
+  .bolao-rail,
+  .bolao-admin-panel {
+    padding: 18px;
+  }
+
+  .bolao-kpis,
+  .match-strip,
+  .bolao-admin-grid {
     grid-template-columns: 1fr;
+  }
+
+  .bolao-game {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .member-row,
+  .log-row,
+  .bolao-row {
+    grid-template-columns: 1fr;
+  }
+
+  .bolao-row em {
+    text-align: left;
   }
 
   .member-actions {

--- a/src/backend/routes/user.js
+++ b/src/backend/routes/user.js
@@ -15,6 +15,18 @@ router.get("/user", user_info);
 
 router.get("/me", isLogin, me);
 
+router.get("/panel/bolao", isLogin, panel.bolaoHome);
+
+router.post("/panel/bolao/games", isLogin, panel.bolaoCreateGame);
+
+router.get("/panel/bolao/:gameId", isLogin, panel.bolaoDetails);
+
+router.post("/panel/bolao/:gameId/bets", isLogin, panel.bolaoBet);
+
+router.post("/panel/bolao/:gameId/result", isLogin, panel.bolaoResultPreview);
+
+router.post("/panel/bolao/:gameId/payout", isLogin, panel.bolaoPayoutConfirm);
+
 router.get("/panel/groups/:groupId", isLogin, panel.groupDetails);
 
 router.get("/panel/groups", isLogin, panel.listGroups);

--- a/src/backend/services/panelService.js
+++ b/src/backend/services/panelService.js
@@ -146,7 +146,8 @@ function compactGroup(group, extras = {}) {
       prefixo: group.configs?.prefixo || "/",
       autoReply: group.autoReply !== false,
       autoDownload: group.autoDownload !== false,
-      antiTotag: !!group.antiTotag
+      antiTotag: !!group.antiTotag,
+      bolao: group.configs?.bolao !== false
     },
     ...extras
   };
@@ -228,7 +229,8 @@ async function buildPanelHome(sender) {
     permissions: {
       canUseOps: role.level > 0,
       canUseAnnouncements: role.level > 0,
-      canManageAnyGroup: role.level > 0
+      canManageAnyGroup: role.level > 0,
+      canManageBolao: role.level >= 2
     },
     csrfToken: null,
     groups,
@@ -370,7 +372,8 @@ async function updateGroupConfig(sock, groupId, sender, input) {
     autoReply: "autoReply",
     autoDownload: "autoDownload",
     antiTotag: "antiTotag",
-    events: "configs.events"
+    events: "configs.events",
+    bolao: "configs.bolao"
   };
 
   const set = {};

--- a/src/commands/donos/testebolao.js
+++ b/src/commands/donos/testebolao.js
@@ -1,0 +1,61 @@
+const { createGame, formatDateTime, isBolaoAdmin } = require("../../services/bolaoService");
+const { reconcileBolaoOnce } = require("../../services/bolaoScheduler");
+const { ensureGroup } = require("../../utils/dbHelpers");
+
+module.exports = {
+  name: "testebolao",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      if (!(await isBolaoAdmin(sender))) {
+        await sock.sendMessage(from, {text: "So dono real da Yuki pode rodar teste de bolao."}, {quoted: msg});
+        return;
+      }
+
+      if (!from.endsWith("@g.us")) {
+        await sock.sendMessage(from, {text: "Use /testebolao dentro do grupo que vai receber o teste."}, {quoted: msg});
+        return;
+      }
+
+      let metadata = {};
+      try {
+        metadata = await sock.groupMetadata(from);
+        await ensureGroup(from, metadata);
+      } catch (err) {
+        console.error("[testebolao] nao consegui atualizar metadata:", err?.message || err);
+      }
+
+      const now = Date.now();
+      const game = await createGame({
+        homeTeam: "Brasil Teste",
+        awayTeam: "Yuki FC",
+        competition: "Simulacao interna",
+        startsAt: new Date(now + 3 * 60 * 1000),
+        bettingOpensAt: new Date(now - 1000),
+        bettingClosesAt: new Date(now + 90 * 1000),
+        reminderAt: new Date(now + 45 * 1000),
+        resultPromptAt: new Date(now + 4 * 60 * 1000),
+        targetGroupIds: [from],
+        source: "test"
+      }, sender, {testMode: true});
+
+      await reconcileBolaoOnce(sock);
+
+      await sock.sendMessage(from, {
+        text: `Teste do bolao criado para este grupo.
+
+Codigo: ${game.code}
+Fecha: ${formatDateTime(game.bettingClosesAt)}
+
+Teste uma aposta:
+/bolao apostar ${game.code} 2x1 100
+
+Depois do fechamento, teste:
+/bolao resultado ${game.code} 2x1
+/bolao pagar ${game.code}`
+      }, {quoted: msg});
+    } catch (err) {
+      await sock.sendMessage(from, {text: err?.status ? err.message : (erros_prontos || "Falha no teste do bolao.")}, {quoted: msg});
+      if (!err?.status) console.error("Erro no /testebolao:", err);
+    }
+  }
+};

--- a/src/commands/donos/testebolaoAcento.js
+++ b/src/commands/donos/testebolaoAcento.js
@@ -1,0 +1,6 @@
+const testebolao = require("./testebolao");
+
+module.exports = {
+  ...testebolao,
+  name: "testebolão"
+};

--- a/src/commands/economia/bolao.js
+++ b/src/commands/economia/bolao.js
@@ -1,0 +1,282 @@
+const { prefixo } = require("../../config");
+const {
+  cancelGame,
+  confirmPayout,
+  createGame,
+  createResultPreview,
+  formatDateTime,
+  formatMoney,
+  getCommandStatus,
+  getOpenGames,
+  isBolaoAdmin,
+  parseGameCreateText,
+  parseScoreText,
+  placeOrUpdateBet,
+  updateBolaoGroupConfig
+} = require("../../services/bolaoService");
+const { reconcileBolaoOnce } = require("../../services/bolaoScheduler");
+
+function commandPrefix() {
+  return prefixo || "/";
+}
+
+async function sendHelp(sock, msg, from) {
+  const p = commandPrefix();
+  await sock.sendMessage(from, {
+    text: `*Bolao da Yuki*
+
+Usuario:
+${p}bolao apostar CODIGO 2x1 500
+${p}bolao status CODIGO
+
+Dono:
+${p}bolao criar Brasil x Argentina | 2026-06-14 16:00 | Copa
+${p}bolao resultado CODIGO 2x1
+${p}bolao pagar CODIGO
+${p}bolao cancelar CODIGO motivo
+
+Admin de grupo:
+${p}bolao config 1
+${p}bolao config 0`
+  }, {quoted: msg});
+}
+
+function previewText(game) {
+  const preview = game.payoutPreview || {};
+  const winners = preview.winners || [];
+  const refunds = preview.refunds || [];
+
+  if (!preview.totalBets) {
+    return `Preview gerado para ${game.title}, mas ainda nao existe aposta ativa.`;
+  }
+
+  if (!winners.length) {
+    return `*Preview do resultado*
+
+${game.title}: ${game.result?.score}
+Apostas: ${preview.totalBets}
+Pool: ${formatMoney(preview.pool)}
+
+Ninguem cravou. Ao confirmar, a Yuki reembolsa ${refunds.length} apostas.`;
+  }
+
+  const top = winners
+    .slice(0, 8)
+    .map((winner, index) => `${index + 1}. ${winner.name || winner.userLid} - +${formatMoney(winner.total)}`)
+    .join("\n");
+
+  return `*Preview do resultado*
+
+${game.title}: ${game.result?.score}
+Apostas: ${preview.totalBets}
+Pool: ${formatMoney(preview.pool)}
+Ganhadores: ${preview.winnerCount}
+Pagamento total: ${formatMoney(preview.totalPayout)}
+
+${top}${winners.length > 8 ? "\n..." : ""}`;
+}
+
+async function handleCreate(sock, msg, from, args, sender) {
+  if (!(await isBolaoAdmin(sender))) {
+    await sock.sendMessage(from, {text: "So dono real da Yuki pode criar bolao."}, {quoted: msg});
+    return;
+  }
+
+  const input = parseGameCreateText(args.slice(1).join(" "));
+  const game = await createGame(input, sender);
+  await sock.sendMessage(from, {
+    text: `Bolao criado.
+
+Codigo: ${game.code}
+Jogo: ${game.title}
+Abre: ${formatDateTime(game.bettingOpensAt)}
+Fecha: ${formatDateTime(game.bettingClosesAt)}
+
+Quando abrir, a Yuki manda nos grupos ativos com bolao ligado.`
+  }, {quoted: msg});
+
+  await reconcileBolaoOnce(sock);
+}
+
+async function handleBet(sock, msg, from, args, sender) {
+  const code = args[1];
+  const scoreText = args[2];
+  const amount = Number(args[3]);
+
+  if (!code || !scoreText || !amount) {
+    await sock.sendMessage(from, {text: `Use: ${commandPrefix()}bolao apostar CODIGO 2x1 500`}, {quoted: msg});
+    return;
+  }
+
+  const score = parseScoreText(scoreText);
+  const result = await placeOrUpdateBet({
+    gameId: code,
+    sender,
+    name: msg.pushName || "Sem nome",
+    groupId: from.endsWith("@g.us") ? from : null,
+    homeScore: score.home,
+    awayScore: score.away,
+    amount
+  });
+
+  await sock.sendMessage(from, {
+    text: `Bilhete confirmado.
+
+Jogo: ${result.game.title}
+Placar: ${result.bet.score}
+Valor: ${formatMoney(result.bet.stake)} moedas
+
+Voce pode editar ate fechar, usando o mesmo comando.`
+  }, {quoted: msg});
+}
+
+async function handleStatus(sock, msg, from, args) {
+  const ref = args[1];
+  if (!ref) {
+    const games = await getOpenGames();
+    if (!games.length) {
+      await sock.sendMessage(from, {text: "Nenhum bolao aberto agora."}, {quoted: msg});
+      return;
+    }
+
+    const text = games
+      .map((game) => `${game.code} - ${game.title} - fecha ${formatDateTime(game.bettingClosesAt)}`)
+      .join("\n");
+    await sock.sendMessage(from, {text: `Boloes abertos:\n${text}`}, {quoted: msg});
+    return;
+  }
+
+  const { game, bets } = await getCommandStatus(ref);
+  const showBets = ["closed", "awaiting_result", "result_pending_confirmation", "paid", "refunded"].includes(game.status);
+  const betText = showBets && bets.length
+    ? `\n\nApostas:\n${bets.slice(0, 8).map((bet) => `${bet.name}: ${bet.score} (${formatMoney(bet.stake)})`).join("\n")}`
+    : "";
+
+  await sock.sendMessage(from, {
+    text: `*${game.title}*
+Codigo: ${game.code}
+Status: ${game.statusLabel}
+Jogo: ${formatDateTime(game.startsAt)}
+Fecha: ${formatDateTime(game.bettingClosesAt)}
+Pool: ${formatMoney(game.pool || 0)}
+Apostas: ${game.bets || 0}${betText}`
+  }, {quoted: msg});
+}
+
+async function handleResult(sock, msg, from, args, sender) {
+  if (!(await isBolaoAdmin(sender))) {
+    await sock.sendMessage(from, {text: "So dono real da Yuki pode fechar resultado."}, {quoted: msg});
+    return;
+  }
+
+  const code = args[1];
+  const scoreText = args[2];
+  if (!code || !scoreText) {
+    await sock.sendMessage(from, {text: `Use: ${commandPrefix()}bolao resultado CODIGO 2x1`}, {quoted: msg});
+    return;
+  }
+
+  const game = await createResultPreview(code, sender, scoreText);
+  const buttons = [
+    {buttonId: `${commandPrefix()}bolao pagar ${game.code}`, buttonText: {displayText: "Confirmar pagamento"}, type: 1}
+  ];
+
+  await sock.sendMessage(from, {
+    text: `${previewText(game)}
+
+Confirme apenas se o placar estiver certo.`,
+    footer: "Modo seguro: nada e pago antes da confirmacao.",
+    buttons
+  }, {quoted: msg});
+}
+
+async function handlePay(sock, msg, from, args, sender) {
+  if (!(await isBolaoAdmin(sender))) {
+    await sock.sendMessage(from, {text: "So dono real da Yuki pode pagar bolao."}, {quoted: msg});
+    return;
+  }
+
+  const code = args[1];
+  if (!code) {
+    await sock.sendMessage(from, {text: `Use: ${commandPrefix()}bolao pagar CODIGO`}, {quoted: msg});
+    return;
+  }
+
+  const game = await confirmPayout(code, sender);
+  await reconcileBolaoOnce(sock);
+
+  await sock.sendMessage(from, {
+    text: `Bolao encerrado.
+
+${game.title}
+Status: ${game.statusLabel}
+Pool: ${formatMoney(game.payoutPreview?.pool || 0)}
+Ganhadores: ${game.payoutPreview?.winnerCount || 0}`
+  }, {quoted: msg});
+}
+
+async function handleCancel(sock, msg, from, args, sender) {
+  if (!(await isBolaoAdmin(sender))) {
+    await sock.sendMessage(from, {text: "So dono real da Yuki pode cancelar bolao."}, {quoted: msg});
+    return;
+  }
+
+  const code = args[1];
+  const reason = args.slice(2).join(" ") || "cancelado pelo dono";
+  if (!code) {
+    await sock.sendMessage(from, {text: `Use: ${commandPrefix()}bolao cancelar CODIGO motivo`}, {quoted: msg});
+    return;
+  }
+
+  const result = await cancelGame(code, sender, reason);
+  await sock.sendMessage(from, {
+    text: `Bolao cancelado.
+
+${result.game.title}
+Reembolsos: ${result.refunded}`
+  }, {quoted: msg});
+}
+
+async function handleConfig(sock, msg, from, args, sender) {
+  if (!from.endsWith("@g.us")) {
+    await sock.sendMessage(from, {text: "Use essa config dentro de um grupo."}, {quoted: msg});
+    return;
+  }
+
+  const value = String(args[1] || "").toLowerCase();
+  if (!["0", "1", "on", "off", "ativar", "desativar"].includes(value)) {
+    await sock.sendMessage(from, {text: `Use: ${commandPrefix()}bolao config 1 ou ${commandPrefix()}bolao config 0`}, {quoted: msg});
+    return;
+  }
+
+  const enabled = ["1", "on", "ativar"].includes(value);
+  const group = await updateBolaoGroupConfig(sock, from, sender, enabled);
+  await sock.sendMessage(from, {
+    text: `Bolao ${group.bolao ? "ativado" : "desativado"} em ${group.name || "este grupo"}.`
+  }, {quoted: msg});
+}
+
+module.exports = {
+  name: "bolao",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      const action = String(args[0] || "status").toLowerCase();
+
+      if (["help", "ajuda"].includes(action)) return sendHelp(sock, msg, from);
+      if (action === "criar") return handleCreate(sock, msg, from, args, sender);
+      if (["apostar", "aposta"].includes(action)) return handleBet(sock, msg, from, args, sender);
+      if (["status", "ver"].includes(action)) return handleStatus(sock, msg, from, args);
+      if (["resultado", "result"].includes(action)) return handleResult(sock, msg, from, args, sender);
+      if (["pagar", "confirmar"].includes(action)) return handlePay(sock, msg, from, args, sender);
+      if (["cancelar", "cancel"].includes(action)) return handleCancel(sock, msg, from, args, sender);
+      if (["config", "grupo"].includes(action)) return handleConfig(sock, msg, from, args, sender);
+
+      return sendHelp(sock, msg, from);
+    } catch (err) {
+      const status = err?.status || 500;
+      const text = status < 500 ? err.message : (erros_prontos || "Deu ruim no bolao.");
+      await sock.sendMessage(from, {text}, {quoted: msg});
+      if (status >= 500) console.error("Erro no comando /bolao:", err);
+    }
+  }
+};

--- a/src/commands/economia/bolaoAcento.js
+++ b/src/commands/economia/bolaoAcento.js
@@ -1,0 +1,6 @@
+const bolao = require("./bolao");
+
+module.exports = {
+  ...bolao,
+  name: "bolão"
+};

--- a/src/database/models/bolao.js
+++ b/src/database/models/bolao.js
@@ -1,0 +1,161 @@
+const mongoose = require("mongoose");
+
+const scoreSchema = new mongoose.Schema({
+  home: {type: Number, default: null},
+  away: {type: Number, default: null}
+}, {_id: false});
+
+const payoutUserSchema = new mongoose.Schema({
+  userLid: {type: String, required: true},
+  name: {type: String, default: "Sem nome"},
+  stake: {type: Number, default: 0},
+  score: {type: scoreSchema, default: () => ({})},
+  poolShare: {type: Number, default: 0},
+  bonus: {type: Number, default: 0},
+  total: {type: Number, default: 0}
+}, {_id: false});
+
+const gameSchema = new mongoose.Schema({
+  code: {type: String, required: true, unique: true, index: true},
+  competition: {type: String, default: "Copa do Mundo"},
+  homeTeam: {type: String, required: true},
+  awayTeam: {type: String, required: true},
+  title: {type: String, required: true},
+  startsAt: {type: Date, required: true, index: true},
+  bettingOpensAt: {type: Date, required: true, index: true},
+  bettingClosesAt: {type: Date, required: true, index: true},
+  reminderAt: {type: Date, required: true, index: true},
+  resultPromptAt: {type: Date, required: true, index: true},
+  status: {
+    type: String,
+    enum: [
+      "scheduled",
+      "open",
+      "closed",
+      "awaiting_result",
+      "result_pending_confirmation",
+      "paying",
+      "paid",
+      "refunded",
+      "cancelled"
+    ],
+    default: "scheduled",
+    index: true
+  },
+  source: {type: String, enum: ["manual", "panel", "test"], default: "manual"},
+  createdBy: {type: String, required: true, index: true},
+  targetGroupIds: {type: [String], default: []},
+  testMode: {type: Boolean, default: false, index: true},
+  config: {
+    minBet: {type: Number, default: 100},
+    payoutMode: {type: String, default: "pool_plus_stake_bonus"},
+    noWinnerPolicy: {type: String, default: "refund_all"}
+  },
+  result: {
+    homeScore: {type: Number, default: null},
+    awayScore: {type: Number, default: null},
+    setBy: {type: String, default: null},
+    setAt: {type: Date, default: null}
+  },
+  payoutPreview: {
+    generatedAt: {type: Date, default: null},
+    pool: {type: Number, default: 0},
+    totalBets: {type: Number, default: 0},
+    winnerCount: {type: Number, default: 0},
+    winnerStake: {type: Number, default: 0},
+    totalBonus: {type: Number, default: 0},
+    totalPayout: {type: Number, default: 0},
+    winners: {type: [payoutUserSchema], default: []},
+    refunds: {type: [payoutUserSchema], default: []}
+  },
+  payoutConfirmedBy: {type: String, default: null},
+  payoutStartedAt: {type: Date, default: null},
+  paidAt: {type: Date, default: null},
+  cancelledAt: {type: Date, default: null},
+  cancelReason: {type: String, default: null}
+}, {timestamps: true});
+
+gameSchema.index({status: 1, startsAt: 1});
+gameSchema.index({status: 1, bettingOpensAt: 1});
+gameSchema.index({status: 1, bettingClosesAt: 1});
+
+const betSchema = new mongoose.Schema({
+  gameId: {type: mongoose.Schema.Types.ObjectId, required: true, index: true},
+  gameCode: {type: String, required: true, index: true},
+  userLid: {type: String, required: true, index: true},
+  name: {type: String, default: "Sem nome"},
+  groupId: {type: String, default: null, index: true},
+  homeScore: {type: Number, required: true},
+  awayScore: {type: Number, required: true},
+  stake: {type: Number, required: true},
+  status: {
+    type: String,
+    enum: ["active", "paid", "lost", "refunded", "cancelled"],
+    default: "active",
+    index: true
+  },
+  paidAmount: {type: Number, default: 0},
+  placedAt: {type: Date, default: Date.now},
+  updatedAt: {type: Date, default: Date.now},
+  revision: {type: Number, default: 1}
+});
+
+betSchema.index({gameId: 1, userLid: 1}, {unique: true});
+betSchema.index({gameId: 1, status: 1});
+
+const ledgerSchema = new mongoose.Schema({
+  transactionId: {type: String, required: true, unique: true, index: true},
+  gameId: {type: mongoose.Schema.Types.ObjectId, required: true, index: true},
+  gameCode: {type: String, required: true, index: true},
+  userLid: {type: String, required: true, index: true},
+  type: {
+    type: String,
+    enum: ["stake", "stake_adjust", "refund", "payout", "cancel_refund"],
+    required: true,
+    index: true
+  },
+  amount: {type: Number, required: true},
+  status: {type: String, enum: ["pending", "applied", "failed"], default: "pending", index: true},
+  meta: {type: Object, default: {}},
+  lockedAt: {type: Date, default: null},
+  appliedAt: {type: Date, default: null},
+  error: {type: String, default: null},
+  createdAt: {type: Date, default: Date.now, index: true}
+});
+
+ledgerSchema.index({gameId: 1, userLid: 1, type: 1});
+
+const deliverySchema = new mongoose.Schema({
+  dedupeKey: {type: String, required: true, unique: true, index: true},
+  gameId: {type: mongoose.Schema.Types.ObjectId, default: null, index: true},
+  gameCode: {type: String, default: null, index: true},
+  targetId: {type: String, required: true, index: true},
+  kind: {
+    type: String,
+    enum: ["owner_daily", "owner_review", "open", "reminder", "closed", "result_prompt", "paid", "refunded"],
+    required: true,
+    index: true
+  },
+  status: {type: String, enum: ["pending", "success", "failed"], default: "pending", index: true},
+  attempts: {type: Number, default: 0},
+  lastError: {type: String, default: null},
+  lockedAt: {type: Date, default: null},
+  sentAt: {type: Date, default: null},
+  messageId: {type: String, default: null},
+  createdAt: {type: Date, default: Date.now, index: true},
+  updatedAt: {type: Date, default: Date.now}
+});
+
+deliverySchema.index({gameId: 1, kind: 1, targetId: 1});
+
+const bolaoGames = mongoose.model("bolaoGame", gameSchema);
+const bolaoBets = mongoose.model("bolaoBet", betSchema);
+const bolaoLedgers = mongoose.model("bolaoLedger", ledgerSchema);
+const bolaoDeliveries = mongoose.model("bolaoDelivery", deliverySchema);
+
+module.exports = {
+  bolaoBets,
+  bolaoDeliveries,
+  bolaoGames,
+  bolaoLedgers
+};

--- a/src/database/models/grupos.js
+++ b/src/database/models/grupos.js
@@ -11,7 +11,8 @@ const schema = new mongoose.Schema({
     welcome: {type: Boolean, default: true},
     antlink: {type: Boolean, default: false},
     cmdFun: {type: Boolean, default: false},
-    cmdAdulto: {type: Boolean, default: false}
+    cmdAdulto: {type: Boolean, default: false},
+    bolao: {type: Boolean, default: true}
   },
   lang: {type: String, default: "pt-br"},
   autoReply: {type: Boolean, default: true},

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ const { redisConnect } = require("./lib/redis.js");
 const os = require("os");
 require("dotenv").config({ quiet: true });
 const server = require("./backend/server.js");
+const { startBolaoScheduler } = require("./services/bolaoScheduler.js");
 
 let isBooting = false;
 let reconnectTimeout = null;
@@ -131,6 +132,7 @@ async function yukibot() {
     });
 
     server(sock);
+    startBolaoScheduler(sock);
     require("./events/messages.js")(sock, commandsMap, erros_prontos, espera_pronta);
     require("./events/participantUp")(sock);
     require("./events/waifus.js")(sock);

--- a/src/services/bolaoScheduler.js
+++ b/src/services/bolaoScheduler.js
@@ -1,0 +1,215 @@
+const { bolaoGames } = require("../database/models/bolao");
+const {
+  buildOwnerReviewText,
+  buildResultPromptText,
+  confirmPayout,
+  getCuratorLids,
+  getEnabledBolaoGroups,
+  sendBolaoGroupDelivery,
+  sendOwnerDelivery
+} = require("./bolaoService");
+
+const RECONCILE_INTERVAL_MS = Number(process.env.BOLAO_RECONCILE_INTERVAL_MS || 60 * 1000);
+const OWNER_REVIEW_BEFORE_MS = 20 * 60 * 1000;
+
+let schedulerTimer = null;
+let activeSock = null;
+let running = false;
+
+function due(date, now) {
+  return date && new Date(date).getTime() <= now.getTime();
+}
+
+async function sendToGameGroups(sock, game, kind) {
+  const groups = await getEnabledBolaoGroups(game);
+  for (const group of groups) {
+    try {
+      await sendBolaoGroupDelivery(sock, group, game, kind);
+    } catch (err) {
+      console.error(`[bolao] falha ao enviar ${kind} para ${group.groupId}:`, err?.message || err);
+    }
+  }
+}
+
+async function sendToCurators(sock, game, kind, text) {
+  for (const ownerLid of getCuratorLids()) {
+    try {
+      await sendOwnerDelivery(sock, ownerLid, kind, text, game);
+    } catch (err) {
+      console.error(`[bolao] falha ao avisar curador ${ownerLid}:`, err?.message || err);
+    }
+  }
+}
+
+async function reconcileOwnerDailyPrompt(sock, now) {
+  const configuredHour = Number(process.env.BOLAO_DAILY_PROMPT_HOUR || 9);
+  if (!Number.isInteger(configuredHour) || configuredHour < 0 || configuredHour > 23) return;
+
+  const localHour = Number(now.toLocaleString("pt-BR", {
+    timeZone: "America/Sao_Paulo",
+    hour: "2-digit",
+    hour12: false
+  }));
+  const localDate = now.toLocaleDateString("pt-BR", {timeZone: "America/Sao_Paulo"});
+  const dailyKey = localDate.replace(/\D/g, "");
+
+  if (localHour !== configuredHour) return;
+
+  const text = `Curadoria do bolao da Yuki
+
+Tem jogo hoje? Se tiver, cadastra assim:
+/bolao criar Brasil x Argentina | 2026-06-14 16:00 | Copa
+
+Tambem da para cadastrar pelo painel, na aba Bolao.`;
+
+  for (const ownerLid of getCuratorLids()) {
+    try {
+      await sendOwnerDelivery(sock, ownerLid, "owner_daily", text, null, {
+        dedupeKey: `bolao:daily:${dailyKey}:${ownerLid}`
+      });
+    } catch (err) {
+      console.error(`[bolao] falha no prompt diario para ${ownerLid}:`, err?.message || err);
+    }
+  }
+}
+
+async function reconcileGame(sock, game, now) {
+  const reviewAt = new Date(new Date(game.bettingOpensAt).getTime() - OWNER_REVIEW_BEFORE_MS);
+
+  if (due(reviewAt, now)) {
+    await sendToCurators(sock, game, "owner_review", buildOwnerReviewText(game));
+  }
+
+  if (["scheduled"].includes(game.status) && due(game.bettingOpensAt, now)) {
+    const opened = await bolaoGames.findOneAndUpdate(
+      {_id: game._id, status: "scheduled"},
+      {$set: {status: "open"}},
+      {new: true}
+    );
+    if (opened) {
+      await sendToGameGroups(sock, opened, "open");
+      game.status = "open";
+    }
+  }
+
+  if (game.status === "open" && due(game.bettingOpensAt, now)) {
+    await sendToGameGroups(sock, game, "open");
+  }
+
+  if (game.status === "open" && due(game.reminderAt, now)) {
+    await sendToGameGroups(sock, game, "reminder");
+  }
+
+  if (["scheduled", "open"].includes(game.status) && due(game.bettingClosesAt, now)) {
+    const closed = await bolaoGames.findOneAndUpdate(
+      {_id: game._id, status: {$in: ["scheduled", "open"]}},
+      {$set: {status: "closed"}},
+      {new: true}
+    );
+    if (closed) {
+      await sendToGameGroups(sock, closed, "closed");
+      game.status = "closed";
+    }
+  }
+
+  if (["closed"].includes(game.status) && due(game.resultPromptAt, now)) {
+    const waiting = await bolaoGames.findOneAndUpdate(
+      {_id: game._id, status: "closed"},
+      {$set: {status: "awaiting_result"}},
+      {new: true}
+    );
+    if (waiting) {
+      await sendToCurators(sock, waiting, "result_prompt", buildResultPromptText(waiting));
+      game.status = "awaiting_result";
+    }
+  }
+
+  if (game.status === "awaiting_result" && due(game.resultPromptAt, now)) {
+    await sendToCurators(sock, game, "result_prompt", buildResultPromptText(game));
+  }
+
+  if (game.status === "paying") {
+    try {
+      const paid = await confirmPayout(game._id, game.payoutConfirmedBy || game.createdBy);
+      const fresh = await bolaoGames.findById(game._id).lean();
+      if (fresh && ["paid", "refunded"].includes(fresh.status)) {
+        await sendToGameGroups(sock, fresh, fresh.status);
+      }
+      return paid;
+    } catch (err) {
+      console.error(`[bolao] falha ao retomar pagamento ${game.code}:`, err?.message || err);
+    }
+  }
+
+  if (["paid", "refunded"].includes(game.status)) {
+    await sendToGameGroups(sock, game, game.status);
+  }
+
+  return null;
+}
+
+async function reconcileBolaoOnce(sock = activeSock) {
+  if (!sock) return;
+  if (running) return;
+
+  running = true;
+  try {
+    const now = new Date();
+    await reconcileOwnerDailyPrompt(sock, now);
+
+    const horizon = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const recentPaidCutoff = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const games = await bolaoGames
+      .find({
+        $or: [
+          {
+            status: {$in: ["scheduled", "open", "closed", "awaiting_result", "paying"]},
+            startsAt: {$lte: horizon}
+          },
+          {
+            status: {$in: ["paid", "refunded"]},
+            paidAt: {$gte: recentPaidCutoff}
+          }
+        ]
+      })
+      .sort({startsAt: 1})
+      .limit(80);
+
+    for (const game of games) {
+      await reconcileGame(sock, game, now);
+    }
+  } catch (err) {
+    console.error("[bolao] erro no reconciler:", err);
+  } finally {
+    running = false;
+  }
+}
+
+function startBolaoScheduler(sock) {
+  activeSock = sock;
+
+  if (schedulerTimer) return;
+
+  reconcileBolaoOnce(sock).catch((err) => {
+    console.error("[bolao] erro no primeiro reconcile:", err);
+  });
+
+  schedulerTimer = setInterval(() => {
+    reconcileBolaoOnce().catch((err) => {
+      console.error("[bolao] erro no intervalo:", err);
+    });
+  }, RECONCILE_INTERVAL_MS);
+
+  if (typeof schedulerTimer.unref === "function") schedulerTimer.unref();
+}
+
+function stopBolaoScheduler() {
+  if (schedulerTimer) clearInterval(schedulerTimer);
+  schedulerTimer = null;
+}
+
+module.exports = {
+  reconcileBolaoOnce,
+  startBolaoScheduler,
+  stopBolaoScheduler
+};

--- a/src/services/bolaoService.js
+++ b/src/services/bolaoService.js
@@ -1,0 +1,1114 @@
+const crypto = require("crypto");
+const mongoose = require("mongoose");
+const { bolaoBets, bolaoDeliveries, bolaoGames, bolaoLedgers } = require("../database/models/bolao");
+const { grupos } = require("../database/models/grupos");
+const { users } = require("../database/models/users");
+const { ownerLids, prefixo } = require("../config");
+const { ensureGroup, ensureUser, getOwnerLevelCached, updateGroupAndCache, updateUserAndCache } = require("../utils/dbHelpers");
+const { normalizeUserLid } = require("../utils/normalizeUserLid");
+
+const MIN_BET = 100;
+const OPEN_BEFORE_MS = 2 * 60 * 60 * 1000;
+const REMINDER_BEFORE_MS = 30 * 60 * 1000;
+const CLOSE_BEFORE_MS = 10 * 60 * 1000;
+const RESULT_PROMPT_AFTER_MS = 2 * 60 * 60 * 1000;
+const LEDGER_LOCK_TTL_MS = 5 * 60 * 1000;
+const SOCKET_TIMEOUT_MS = 12 * 1000;
+const MAX_MENTIONS = Number(process.env.BOLAO_MAX_MENTIONS || 200);
+
+function httpError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function withTimeout(promise, ms, message) {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), ms);
+  });
+
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout));
+}
+
+function toIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function toObjectId(value) {
+  if (!value) return null;
+  const raw = String(value);
+  if (!mongoose.Types.ObjectId.isValid(raw)) return null;
+  return new mongoose.Types.ObjectId(raw);
+}
+
+function stripAccents(value) {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+function slugPart(value) {
+  return stripAccents(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 22) || "jogo";
+}
+
+function cleanText(value, fallback = "") {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  return text || fallback;
+}
+
+function compactText(value, limit = 80) {
+  const text = cleanText(value);
+  return text.length > limit ? `${text.slice(0, limit - 3)}...` : text;
+}
+
+function formatDateTime(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "sem data";
+  return date.toLocaleString("pt-BR", {
+    timeZone: "America/Sao_Paulo",
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function formatMoney(value) {
+  return Number(value || 0).toLocaleString("pt-BR", {maximumFractionDigits: 0});
+}
+
+function parseLocalDateTime(value) {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+
+  const text = String(value || "").trim();
+  const match = text.match(/^(\d{4})-(\d{2})-(\d{2})(?:[ T])(\d{2}):(\d{2})$/);
+  if (!match) {
+    throw httpError(400, "data invalida. Use YYYY-MM-DD HH:mm.");
+  }
+
+  const [, year, month, day, hour, minute] = match.map(Number);
+  const date = new Date(year, month - 1, day, hour, minute, 0, 0);
+  if (Number.isNaN(date.getTime())) {
+    throw httpError(400, "data invalida.");
+  }
+
+  return date;
+}
+
+function parseScoreText(value) {
+  const match = String(value || "").trim().match(/^(\d{1,2})\s*[xX:-]\s*(\d{1,2})$/);
+  if (!match) throw httpError(400, "placar invalido. Use algo tipo 2x1.");
+  return normalizeScore(match[1], match[2]);
+}
+
+function normalizeScore(homeScore, awayScore) {
+  const home = Number(homeScore);
+  const away = Number(awayScore);
+  if (!Number.isInteger(home) || !Number.isInteger(away) || home < 0 || away < 0 || home > 30 || away > 30) {
+    throw httpError(400, "placar invalido.");
+  }
+  return {home, away};
+}
+
+function parseGameCreateText(text) {
+  const parts = String(text || "").split("|").map((part) => part.trim()).filter(Boolean);
+  if (parts.length < 2) {
+    throw httpError(400, "use: /bolao criar Brasil x Argentina | 2026-06-14 16:00 | Copa");
+  }
+
+  const teams = parts[0].split(/\s+(?:x|vs|versus)\s+/i).map((part) => cleanText(part));
+  if (teams.length !== 2 || !teams[0] || !teams[1]) {
+    throw httpError(400, "times invalidos. Use: Brasil x Argentina.");
+  }
+
+  return {
+    homeTeam: teams[0],
+    awayTeam: teams[1],
+    startsAt: parseLocalDateTime(parts[1]),
+    competition: parts[2] || "Copa do Mundo"
+  };
+}
+
+function buildPanelLink(gameId) {
+  const base = process.env.URL_BACKEND || "";
+  if (!base) return `/painel#bolao/${gameId}`;
+
+  const url = new URL("/painel", base);
+  url.hash = `bolao/${gameId}`;
+  return url.toString();
+}
+
+function getCuratorLids() {
+  const configured = String(process.env.BOLAO_CURATOR_LIDS || "")
+    .split(",")
+    .map((item) => normalizeUserLid(item))
+    .filter(Boolean);
+
+  return configured.length ? configured : ownerLids.filter(Boolean);
+}
+
+async function isBolaoAdmin(sender) {
+  return (await getOwnerLevelCached(sender)) >= 2;
+}
+
+async function assertBolaoAdmin(sender) {
+  if (!(await isBolaoAdmin(sender))) {
+    throw httpError(403, "somente dono real da Yuki pode gerenciar o bolao.");
+  }
+}
+
+function gameTitle(input) {
+  return `${cleanText(input.homeTeam, "Time A")} x ${cleanText(input.awayTeam, "Time B")}`;
+}
+
+async function createGame(input, sender, options = {}) {
+  if (!options.skipPermission) await assertBolaoAdmin(sender);
+
+  const startsAt = input.startsAt instanceof Date ? input.startsAt : parseLocalDateTime(input.startsAt);
+  const now = new Date();
+  if (!options.testMode && startsAt.getTime() <= now.getTime() + CLOSE_BEFORE_MS) {
+    throw httpError(400, "crie jogos com pelo menos 10 minutos de antecedencia.");
+  }
+
+  const bettingOpensAt = input.bettingOpensAt ? new Date(input.bettingOpensAt) : new Date(startsAt.getTime() - OPEN_BEFORE_MS);
+  const bettingClosesAt = input.bettingClosesAt ? new Date(input.bettingClosesAt) : new Date(startsAt.getTime() - CLOSE_BEFORE_MS);
+  const reminderAt = input.reminderAt ? new Date(input.reminderAt) : new Date(startsAt.getTime() - REMINDER_BEFORE_MS);
+  const resultPromptAt = input.resultPromptAt ? new Date(input.resultPromptAt) : new Date(startsAt.getTime() + RESULT_PROMPT_AFTER_MS);
+
+  if (Number.isNaN(bettingOpensAt.getTime()) || Number.isNaN(bettingClosesAt.getTime())) {
+    throw httpError(400, "janela de apostas invalida.");
+  }
+
+  if (bettingClosesAt.getTime() <= bettingOpensAt.getTime()) {
+    throw httpError(400, "fechamento precisa ser depois da abertura.");
+  }
+
+  const targetGroupIds = Array.from(new Set((input.targetGroupIds || []).filter((id) => String(id || "").endsWith("@g.us"))));
+  const baseCode = `${slugPart(input.homeTeam)}-${slugPart(input.awayTeam)}`;
+  const status = now >= bettingClosesAt
+    ? "closed"
+    : now >= bettingOpensAt
+      ? "open"
+      : "scheduled";
+
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const code = `${baseCode}-${crypto.randomBytes(2).toString("hex")}`;
+    try {
+      return await bolaoGames.create({
+        code,
+        competition: cleanText(input.competition, "Copa do Mundo"),
+        homeTeam: cleanText(input.homeTeam, "Time A"),
+        awayTeam: cleanText(input.awayTeam, "Time B"),
+        title: gameTitle(input),
+        startsAt,
+        bettingOpensAt,
+        bettingClosesAt,
+        reminderAt,
+        resultPromptAt,
+        status,
+        source: input.source || (options.testMode ? "test" : "manual"),
+        createdBy: sender,
+        targetGroupIds,
+        testMode: !!options.testMode,
+        config: {
+          minBet: Number(input.minBet || MIN_BET),
+          payoutMode: "pool_plus_stake_bonus",
+          noWinnerPolicy: "refund_all"
+        }
+      });
+    } catch (err) {
+      if (err?.code !== 11000 || attempt === 4) throw err;
+    }
+  }
+
+  throw httpError(500, "nao consegui gerar codigo unico para o jogo.");
+}
+
+async function findGameByRef(ref) {
+  const raw = String(ref || "").trim();
+  if (!raw) throw httpError(400, "jogo ausente.");
+
+  const objectId = toObjectId(raw);
+  const query = objectId ? {$or: [{_id: objectId}, {code: raw}]} : {code: raw};
+  const game = await bolaoGames.findOne(query);
+  if (!game) throw httpError(404, "jogo nao encontrado.");
+  return game;
+}
+
+function serializeBet(bet) {
+  if (!bet) return null;
+  return {
+    id: String(bet._id),
+    gameId: String(bet.gameId),
+    gameCode: bet.gameCode,
+    userLid: bet.userLid,
+    name: bet.name,
+    groupId: bet.groupId,
+    score: `${bet.homeScore}x${bet.awayScore}`,
+    homeScore: bet.homeScore,
+    awayScore: bet.awayScore,
+    stake: bet.stake,
+    status: bet.status,
+    paidAmount: bet.paidAmount || 0,
+    placedAt: toIso(bet.placedAt),
+    updatedAt: toIso(bet.updatedAt)
+  };
+}
+
+function statusLabel(status) {
+  const labels = {
+    scheduled: "Agendado",
+    open: "Aberto",
+    closed: "Fechado",
+    awaiting_result: "Aguardando resultado",
+    result_pending_confirmation: "Resultado em preview",
+    paying: "Pagando",
+    paid: "Pago",
+    refunded: "Reembolsado",
+    cancelled: "Cancelado"
+  };
+
+  return labels[status] || status;
+}
+
+function serializePreview(preview = {}) {
+  return {
+    generatedAt: toIso(preview.generatedAt),
+    pool: preview.pool || 0,
+    totalBets: preview.totalBets || 0,
+    winnerCount: preview.winnerCount || 0,
+    winnerStake: preview.winnerStake || 0,
+    totalBonus: preview.totalBonus || 0,
+    totalPayout: preview.totalPayout || 0,
+    winners: (preview.winners || []).map((winner) => ({
+      userLid: winner.userLid,
+      name: winner.name,
+      stake: winner.stake,
+      score: `${winner.score?.home ?? 0}x${winner.score?.away ?? 0}`,
+      poolShare: winner.poolShare || 0,
+      bonus: winner.bonus || 0,
+      total: winner.total || 0
+    })),
+    refunds: (preview.refunds || []).map((refund) => ({
+      userLid: refund.userLid,
+      name: refund.name,
+      stake: refund.stake,
+      score: `${refund.score?.home ?? 0}x${refund.score?.away ?? 0}`,
+      total: refund.total || refund.stake || 0
+    }))
+  };
+}
+
+function serializeGame(game, extras = {}) {
+  const raw = typeof game.toObject === "function" ? game.toObject() : game;
+  const id = String(raw._id);
+  const now = Date.now();
+  const canBet = raw.status === "open" && now < new Date(raw.bettingClosesAt).getTime();
+
+  return {
+    id,
+    code: raw.code,
+    title: raw.title,
+    competition: raw.competition,
+    homeTeam: raw.homeTeam,
+    awayTeam: raw.awayTeam,
+    startsAt: toIso(raw.startsAt),
+    bettingOpensAt: toIso(raw.bettingOpensAt),
+    bettingClosesAt: toIso(raw.bettingClosesAt),
+    reminderAt: toIso(raw.reminderAt),
+    resultPromptAt: toIso(raw.resultPromptAt),
+    status: raw.status,
+    statusLabel: statusLabel(raw.status),
+    canBet,
+    testMode: !!raw.testMode,
+    publicLink: buildPanelLink(id),
+    result: raw.result?.homeScore !== null && raw.result?.awayScore !== null ? {
+      score: `${raw.result.homeScore}x${raw.result.awayScore}`,
+      homeScore: raw.result.homeScore,
+      awayScore: raw.result.awayScore,
+      setAt: toIso(raw.result.setAt)
+    } : null,
+    payoutPreview: serializePreview(raw.payoutPreview),
+    ...extras
+  };
+}
+
+async function getGameStats(gameIds) {
+  if (!gameIds.length) return new Map();
+
+  const stats = await bolaoBets.aggregate([
+    {$match: {gameId: {$in: gameIds}, status: "active"}},
+    {$group: {_id: "$gameId", pool: {$sum: "$stake"}, bets: {$sum: 1}}}
+  ]);
+
+  return new Map(stats.map((item) => [String(item._id), {pool: item.pool || 0, bets: item.bets || 0}]));
+}
+
+async function listPanelBolao(sender) {
+  const now = new Date();
+  const since = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+  const games = await bolaoGames
+    .find({
+      $or: [
+        {startsAt: {$gte: since}},
+        {status: {$in: ["scheduled", "open", "closed", "awaiting_result", "result_pending_confirmation", "paying"]}}
+      ],
+      status: {$ne: "cancelled"}
+    })
+    .sort({startsAt: 1})
+    .limit(40)
+    .lean();
+
+  const ids = games.map((game) => game._id);
+  const [stats, userBets, admin, user] = await Promise.all([
+    getGameStats(ids),
+    ids.length ? bolaoBets.find({gameId: {$in: ids}, userLid: sender}).lean() : [],
+    isBolaoAdmin(sender),
+    users.findOne({userLid: sender}).select("dinheiro").lean()
+  ]);
+
+  const betsByGame = new Map(userBets.map((bet) => [String(bet.gameId), bet]));
+  const serializedGames = games.map((game) => {
+    const id = String(game._id);
+    const stat = stats.get(id) || {pool: 0, bets: 0};
+    return serializeGame(game, {
+      pool: stat.pool,
+      bets: stat.bets,
+      userBet: serializeBet(betsByGame.get(id))
+    });
+  });
+
+  const userActiveStake = userBets
+    .filter((bet) => bet.status === "active")
+    .reduce((sum, bet) => sum + Number(bet.stake || 0), 0);
+
+  return {
+    canManage: admin,
+    balance: user?.dinheiro || 0,
+    stats: {
+      openGames: serializedGames.filter((game) => game.status === "open").length,
+      pendingResults: serializedGames.filter((game) => ["closed", "awaiting_result", "result_pending_confirmation"].includes(game.status)).length,
+      activeStake: userActiveStake,
+      totalGames: serializedGames.length
+    },
+    games: serializedGames
+  };
+}
+
+async function getPanelBolaoGame(sender, gameRef) {
+  const game = await findGameByRef(gameRef);
+  const gameId = game._id;
+  const admin = await isBolaoAdmin(sender);
+  const [stats, userBet, activeBets, finishedBets] = await Promise.all([
+    getGameStats([gameId]),
+    bolaoBets.findOne({gameId, userLid: sender}).lean(),
+    admin || ["closed", "awaiting_result", "result_pending_confirmation", "paying"].includes(game.status)
+      ? bolaoBets.find({gameId, status: "active"}).sort({stake: -1}).limit(100).lean()
+      : Promise.resolve([]),
+    ["paid", "refunded"].includes(game.status)
+      ? bolaoBets.find({gameId, status: {$in: ["paid", "refunded", "lost"]}}).sort({paidAmount: -1, stake: -1}).limit(50).lean()
+      : Promise.resolve([])
+  ]);
+
+  const stat = stats.get(String(gameId)) || {pool: 0, bets: 0};
+  return {
+    game: serializeGame(game, {
+      pool: stat.pool,
+      bets: stat.bets,
+      userBet: serializeBet(userBet)
+    }),
+    canManage: admin,
+    bets: activeBets.map((bet) => ({
+      userLid: admin ? bet.userLid : null,
+      name: bet.name,
+      stake: bet.stake,
+      score: admin || ["closed", "awaiting_result", "result_pending_confirmation", "paying"].includes(game.status)
+        ? `${bet.homeScore}x${bet.awayScore}`
+        : null,
+      status: bet.status
+    })),
+    leaderboard: finishedBets.map((bet) => ({
+      name: bet.name,
+      stake: bet.stake,
+      score: `${bet.homeScore}x${bet.awayScore}`,
+      status: bet.status,
+      paidAmount: bet.paidAmount || 0
+    }))
+  };
+}
+
+async function ensureGameOpen(game) {
+  const now = new Date();
+  if (game.status === "scheduled" && now >= game.bettingOpensAt && now < game.bettingClosesAt) {
+    game.status = "open";
+    await game.save();
+  }
+
+  if (game.status !== "open" || now < game.bettingOpensAt || now >= game.bettingClosesAt) {
+    throw httpError(409, "apostas fechadas para esse jogo.");
+  }
+}
+
+async function recordAppliedLedger(input) {
+  await bolaoLedgers.updateOne(
+    {transactionId: input.transactionId},
+    {
+      $setOnInsert: {
+        transactionId: input.transactionId,
+        gameId: input.gameId,
+        gameCode: input.gameCode,
+        userLid: input.userLid,
+        type: input.type,
+        amount: input.amount,
+        status: "applied",
+        appliedAt: new Date(),
+        meta: input.meta || {},
+        createdAt: new Date()
+      }
+    },
+    {upsert: true}
+  );
+}
+
+async function placeOrUpdateBet(input) {
+  const sender = normalizeUserLid(input.sender);
+  const name = cleanText(input.name, "Sem nome");
+  const game = await findGameByRef(input.gameId || input.code);
+  await ensureGameOpen(game);
+
+  const score = normalizeScore(input.homeScore, input.awayScore);
+  const stake = Math.floor(Number(input.amount || input.stake || 0));
+  const minBet = Number(game.config?.minBet || MIN_BET);
+  if (!Number.isFinite(stake) || stake < minBet) {
+    throw httpError(400, `aposta minima: ${minBet} moedas.`);
+  }
+
+  const userDoc = await ensureUser(sender, name);
+  const storedName = userDoc?.name || name;
+
+  const existing = await bolaoBets.findOne({gameId: game._id, userLid: sender}).lean();
+  if (existing && existing.status !== "active") {
+    throw httpError(409, "essa aposta ja foi encerrada.");
+  }
+
+  const previousStake = existing?.stake || 0;
+  const delta = stake - previousStake;
+  let balanceDoc = null;
+
+  if (delta > 0) {
+    balanceDoc = await updateUserAndCache(
+      sender,
+      {$inc: {dinheiro: -delta}},
+      {filter: {dinheiro: {$gte: delta}}, upsert: !existing, name: storedName}
+    );
+
+    if (!balanceDoc) throw httpError(402, "saldo insuficiente para essa aposta.");
+  }
+
+  if (delta < 0) {
+    balanceDoc = await updateUserAndCache(sender, {$inc: {dinheiro: Math.abs(delta)}}, {upsert: true, name: storedName});
+  }
+
+  try {
+    const bet = await bolaoBets.findOneAndUpdate(
+      {gameId: game._id, userLid: sender},
+      {
+        $set: {
+          gameCode: game.code,
+          name: storedName,
+          groupId: input.groupId || existing?.groupId || null,
+          homeScore: score.home,
+          awayScore: score.away,
+          stake,
+          status: "active",
+          updatedAt: new Date()
+        },
+        $setOnInsert: {
+          placedAt: new Date()
+        },
+        $inc: {
+          revision: 1
+        }
+      },
+      {upsert: true, new: true, setDefaultsOnInsert: true}
+    );
+
+    if (delta !== 0) {
+      await recordAppliedLedger({
+        transactionId: `stake:${game._id}:${sender}:${bet.revision}:${Date.now()}`,
+        gameId: game._id,
+        gameCode: game.code,
+        userLid: sender,
+        type: delta > 0 ? "stake" : "stake_adjust",
+        amount: -delta,
+        meta: {previousStake, stake, score}
+      });
+    }
+
+    return {
+      bet: serializeBet(bet),
+      balance: balanceDoc?.dinheiro ?? null,
+      game: serializeGame(game)
+    };
+  } catch (err) {
+    if (delta > 0) await updateUserAndCache(sender, {$inc: {dinheiro: delta}}, {upsert: true, name: storedName});
+    if (delta < 0) await updateUserAndCache(sender, {$inc: {dinheiro: delta}}, {filter: {dinheiro: {$gte: Math.abs(delta)}}});
+    throw err;
+  }
+}
+
+function buildPayout(activeBets, score) {
+  const pool = activeBets.reduce((sum, bet) => sum + Number(bet.stake || 0), 0);
+  const winners = activeBets.filter((bet) => bet.homeScore === score.home && bet.awayScore === score.away);
+  const winnerStake = winners.reduce((sum, bet) => sum + Number(bet.stake || 0), 0);
+
+  if (!winners.length) {
+    return {
+      pool,
+      totalBets: activeBets.length,
+      winnerCount: 0,
+      winnerStake: 0,
+      totalBonus: 0,
+      totalPayout: pool,
+      winners: [],
+      refunds: activeBets.map((bet) => ({
+        userLid: bet.userLid,
+        name: bet.name,
+        stake: bet.stake,
+        score: {home: bet.homeScore, away: bet.awayScore},
+        poolShare: 0,
+        bonus: 0,
+        total: bet.stake
+      }))
+    };
+  }
+
+  const winnerRows = winners
+    .map((bet) => ({
+      userLid: bet.userLid,
+      name: bet.name,
+      stake: bet.stake,
+      score: {home: bet.homeScore, away: bet.awayScore},
+      poolShare: Math.floor((pool * bet.stake) / winnerStake),
+      bonus: bet.stake,
+      total: 0
+    }))
+    .sort((a, b) => b.stake - a.stake || a.userLid.localeCompare(b.userLid));
+
+  let remainder = pool - winnerRows.reduce((sum, row) => sum + row.poolShare, 0);
+  for (let index = 0; remainder > 0 && winnerRows.length; index = (index + 1) % winnerRows.length) {
+    winnerRows[index].poolShare += 1;
+    remainder -= 1;
+  }
+
+  for (const row of winnerRows) {
+    row.total = row.poolShare + row.bonus;
+  }
+
+  return {
+    pool,
+    totalBets: activeBets.length,
+    winnerCount: winnerRows.length,
+    winnerStake,
+    totalBonus: winnerRows.reduce((sum, row) => sum + row.bonus, 0),
+    totalPayout: winnerRows.reduce((sum, row) => sum + row.total, 0),
+    winners: winnerRows,
+    refunds: []
+  };
+}
+
+async function createResultPreview(gameRef, sender, scoreInput) {
+  await assertBolaoAdmin(sender);
+
+  const game = await findGameByRef(gameRef);
+  if (!["closed", "awaiting_result", "result_pending_confirmation"].includes(game.status)) {
+    throw httpError(409, "resultado so entra depois das apostas fecharem.");
+  }
+
+  const score = typeof scoreInput === "string"
+    ? parseScoreText(scoreInput)
+    : normalizeScore(scoreInput.homeScore ?? scoreInput.home, scoreInput.awayScore ?? scoreInput.away);
+
+  const activeBets = await bolaoBets.find({gameId: game._id, status: "active"}).lean();
+  const preview = buildPayout(activeBets, score);
+
+  game.result = {
+    homeScore: score.home,
+    awayScore: score.away,
+    setBy: sender,
+    setAt: new Date()
+  };
+  game.payoutPreview = {
+    generatedAt: new Date(),
+    ...preview
+  };
+  game.status = "result_pending_confirmation";
+  await game.save();
+
+  return serializeGame(game, {
+    pool: preview.pool,
+    bets: preview.totalBets
+  });
+}
+
+async function applyCreditLedger(input) {
+  const now = new Date();
+  await bolaoLedgers.updateOne(
+    {transactionId: input.transactionId},
+    {
+      $setOnInsert: {
+        transactionId: input.transactionId,
+        gameId: input.gameId,
+        gameCode: input.gameCode,
+        userLid: input.userLid,
+        type: input.type,
+        amount: input.amount,
+        status: "pending",
+        meta: input.meta || {},
+        createdAt: now
+      }
+    },
+    {upsert: true}
+  );
+
+  const lockCutoff = new Date(Date.now() - LEDGER_LOCK_TTL_MS);
+  const locked = await bolaoLedgers.findOneAndUpdate(
+    {
+      transactionId: input.transactionId,
+      status: {$ne: "applied"},
+      $or: [{lockedAt: null}, {lockedAt: {$lt: lockCutoff}}]
+    },
+    {$set: {lockedAt: now, status: "pending", error: null}},
+    {new: true}
+  );
+
+  if (!locked) return {applied: false};
+
+  try {
+    await updateUserAndCache(input.userLid, {$inc: {dinheiro: input.amount}}, {upsert: true, name: input.name || "Sem nome"});
+    await bolaoLedgers.updateOne(
+      {transactionId: input.transactionId},
+      {$set: {status: "applied", appliedAt: new Date(), error: null}, $unset: {lockedAt: ""}}
+    );
+    return {applied: true};
+  } catch (err) {
+    await bolaoLedgers.updateOne(
+      {transactionId: input.transactionId},
+      {$set: {status: "failed", error: err?.message || String(err)}, $unset: {lockedAt: ""}}
+    );
+    throw err;
+  }
+}
+
+async function confirmPayout(gameRef, sender) {
+  await assertBolaoAdmin(sender);
+
+  let game = await findGameByRef(gameRef);
+  if (["paid", "refunded"].includes(game.status)) {
+    return serializeGame(game);
+  }
+
+  if (!["result_pending_confirmation", "paying"].includes(game.status)) {
+    throw httpError(409, "gere o preview do resultado antes de pagar.");
+  }
+
+  if (game.status === "result_pending_confirmation") {
+    const locked = await bolaoGames.findOneAndUpdate(
+      {_id: game._id, status: "result_pending_confirmation"},
+      {$set: {status: "paying", payoutStartedAt: new Date(), payoutConfirmedBy: sender}},
+      {new: true}
+    );
+    if (!locked) throw httpError(409, "pagamento ja esta em andamento.");
+    game = locked;
+  }
+
+  const activeBets = await bolaoBets.find({gameId: game._id, status: "active"}).lean();
+  const preview = game.payoutPreview || {};
+  const winners = new Map((preview.winners || []).map((winner) => [winner.userLid, winner]));
+
+  if (!activeBets.length) {
+    game.status = "refunded";
+    game.paidAt = new Date();
+    await game.save();
+    return serializeGame(game);
+  }
+
+  if (!winners.size) {
+    for (const bet of activeBets) {
+      await applyCreditLedger({
+        transactionId: `refund:${game._id}:${bet.userLid}`,
+        gameId: game._id,
+        gameCode: game.code,
+        userLid: bet.userLid,
+        name: bet.name,
+        type: "refund",
+        amount: bet.stake,
+        meta: {reason: "no_winners"}
+      });
+
+      await bolaoBets.updateOne(
+        {_id: bet._id, status: "active"},
+        {$set: {status: "refunded", paidAmount: bet.stake, updatedAt: new Date()}}
+      );
+    }
+
+    game.status = "refunded";
+    game.paidAt = new Date();
+    await game.save();
+    return serializeGame(game);
+  }
+
+  for (const bet of activeBets) {
+    const winner = winners.get(bet.userLid);
+    if (winner) {
+      await applyCreditLedger({
+        transactionId: `payout:${game._id}:${bet.userLid}`,
+        gameId: game._id,
+        gameCode: game.code,
+        userLid: bet.userLid,
+        name: bet.name,
+        type: "payout",
+        amount: winner.total,
+        meta: {poolShare: winner.poolShare, bonus: winner.bonus}
+      });
+
+      await bolaoBets.updateOne(
+        {_id: bet._id, status: "active"},
+        {$set: {status: "paid", paidAmount: winner.total, updatedAt: new Date()}}
+      );
+    } else {
+      await bolaoBets.updateOne(
+        {_id: bet._id, status: "active"},
+        {$set: {status: "lost", paidAmount: 0, updatedAt: new Date()}}
+      );
+    }
+  }
+
+  game.status = "paid";
+  game.paidAt = new Date();
+  await game.save();
+  return serializeGame(game);
+}
+
+async function refundActiveBets(game, type, reason) {
+  const activeBets = await bolaoBets.find({gameId: game._id, status: "active"}).lean();
+  for (const bet of activeBets) {
+    await applyCreditLedger({
+      transactionId: `${type}:${game._id}:${bet.userLid}`,
+      gameId: game._id,
+      gameCode: game.code,
+      userLid: bet.userLid,
+      name: bet.name,
+      type,
+      amount: bet.stake,
+      meta: {reason}
+    });
+
+    await bolaoBets.updateOne(
+      {_id: bet._id, status: "active"},
+      {$set: {status: type === "cancel_refund" ? "cancelled" : "refunded", paidAmount: bet.stake, updatedAt: new Date()}}
+    );
+  }
+
+  return activeBets.length;
+}
+
+async function cancelGame(gameRef, sender, reason = "cancelado pelo dono") {
+  await assertBolaoAdmin(sender);
+  const game = await findGameByRef(gameRef);
+  if (["paid", "refunded", "cancelled"].includes(game.status)) {
+    throw httpError(409, "esse jogo ja foi encerrado.");
+  }
+
+  const refunded = await refundActiveBets(game, "cancel_refund", reason);
+  game.status = "cancelled";
+  game.cancelledAt = new Date();
+  game.cancelReason = reason;
+  await game.save();
+
+  return {game: serializeGame(game), refunded};
+}
+
+async function updateBolaoGroupConfig(sock, groupId, sender, enabled) {
+  const { getGroupPermission } = require("../utils/dbHelpers");
+  const permission = await getGroupPermission(sock, groupId, sender);
+  if (!permission.allowed) throw httpError(403, "sem permissao para alterar o bolao desse grupo.");
+
+  await ensureGroup(groupId, permission.metadata);
+  const group = await updateGroupAndCache(groupId, {$set: {"configs.bolao": !!enabled}}, {metadata: permission.metadata});
+  return {
+    groupId: group.groupId,
+    name: group.grupoName,
+    bolao: group.configs?.bolao !== false
+  };
+}
+
+async function getEnabledBolaoGroups(game) {
+  const ids = Array.from(new Set((game.targetGroupIds || []).filter(Boolean)));
+  if (ids.length) {
+    const docs = await grupos.find({groupId: {$in: ids}}).lean();
+    const map = new Map(docs.map((group) => [group.groupId, group]));
+    return ids.map((id) => map.get(id) || {groupId: id, grupoName: "Grupo do teste", configs: {bolao: true}});
+  }
+
+  return grupos
+    .find({
+      groupId: /@g\.us$/,
+      aluguel: {$gt: new Date()},
+      "configs.bolao": {$ne: false}
+    })
+    .sort({grupoName: 1})
+    .limit(Number(process.env.BOLAO_GROUP_LIMIT || 80))
+    .lean();
+}
+
+function buildDeliveryKey(game, kind, targetId) {
+  return `bolao:${game?._id || "system"}:${kind}:${targetId}`;
+}
+
+async function acquireDelivery({game, kind, targetId, dedupeKey: customDedupeKey}) {
+  const dedupeKey = customDedupeKey || buildDeliveryKey(game, kind, targetId);
+  const now = new Date();
+
+  await bolaoDeliveries.updateOne(
+    {dedupeKey},
+    {
+      $setOnInsert: {
+        dedupeKey,
+        gameId: toObjectId(game?._id) || null,
+        gameCode: game?.code || null,
+        targetId,
+        kind,
+        status: "pending",
+        createdAt: now
+      }
+    },
+    {upsert: true}
+  );
+
+  const lockCutoff = new Date(Date.now() - LEDGER_LOCK_TTL_MS);
+  return bolaoDeliveries.findOneAndUpdate(
+    {
+      dedupeKey,
+      status: {$ne: "success"},
+      attempts: {$lt: 5},
+      $or: [{lockedAt: null}, {lockedAt: {$lt: lockCutoff}}]
+    },
+    {$set: {lockedAt: now, updatedAt: now}, $inc: {attempts: 1}},
+    {new: true}
+  );
+}
+
+async function markDeliverySuccess(delivery, messageId) {
+  await bolaoDeliveries.updateOne(
+    {_id: delivery._id},
+    {$set: {status: "success", sentAt: new Date(), messageId: messageId || null, updatedAt: new Date()}, $unset: {lockedAt: ""}}
+  );
+}
+
+async function markDeliveryFailed(delivery, err) {
+  await bolaoDeliveries.updateOne(
+    {_id: delivery._id},
+    {
+      $set: {
+        status: "failed",
+        lastError: err?.message || String(err),
+        updatedAt: new Date()
+      },
+      $unset: {lockedAt: ""}
+    }
+  );
+}
+
+async function getGroupMentions(sock, groupId) {
+  try {
+    const metadata = await withTimeout(sock.groupMetadata(groupId), SOCKET_TIMEOUT_MS, "metadata demorou");
+    return (metadata.participants || [])
+      .map((participant) => participant.id || participant.lid)
+      .filter(Boolean)
+      .slice(0, MAX_MENTIONS);
+  } catch (err) {
+    console.error("[bolao] nao consegui carregar mencoes:", groupId, err?.message || err);
+    return [];
+  }
+}
+
+function buildBolaoGroupText(game, kind) {
+  const link = buildPanelLink(String(game._id));
+  const header = kind === "reminder"
+    ? "BOLAO DA YUKI - ULTIMA CHAMADA"
+    : kind === "closed"
+      ? "BOLAO DA YUKI - APOSTAS FECHADAS"
+      : "BOLAO DA YUKI LIBERADO";
+
+  if (kind === "closed") {
+    return `*${header}*
+
+${game.title}
+Jogo: ${formatDateTime(game.startsAt)}
+
+Agora e com o campo. Quando o resultado sair, a Yuki calcula os ganhadores e paga automatico depois da confirmacao do dono.`;
+  }
+
+  return `*${header}*
+
+${game.title}
+Competicao: ${game.competition}
+Jogo: ${formatDateTime(game.startsAt)}
+Fecha: ${formatDateTime(game.bettingClosesAt)}
+
+Regra: placar exato. Minimo: ${game.config?.minBet || MIN_BET} moedas.
+Premio: pool dividido entre quem cravar + bonus igual ao valor apostado.
+
+Link seguro: ${link}
+Sem sessao? Use ${prefixo || "/"}painel no WhatsApp e entre pela aba Bolao.`;
+}
+
+function buildBolaoResultText(game) {
+  const preview = game.payoutPreview || {};
+  const score = `${game.result?.homeScore ?? 0}x${game.result?.awayScore ?? 0}`;
+
+  if (!preview.winnerCount) {
+    return `*BOLAO DA YUKI - RESULTADO*
+
+${game.title}: ${score}
+
+Ninguem cravou o placar. A Yuki reembolsou ${preview.totalBets || 0} apostas, totalizando ${formatMoney(preview.pool || 0)} moedas.`;
+  }
+
+  const winners = (preview.winners || [])
+    .slice(0, 8)
+    .map((winner, index) => `${index + 1}. ${winner.name || winner.userLid} - +${formatMoney(winner.total)} moedas`)
+    .join("\n");
+
+  return `*BOLAO DA YUKI - PAGAMENTO FEITO*
+
+${game.title}: ${score}
+
+Pool: ${formatMoney(preview.pool || 0)} moedas
+Ganhadores: ${preview.winnerCount}
+
+${winners}${preview.winnerCount > 8 ? "\n..." : ""}`;
+}
+
+async function sendBolaoGroupDelivery(sock, group, game, kind) {
+  if (!sock) throw new Error("socket indisponivel");
+  const delivery = await acquireDelivery({game, kind, targetId: group.groupId});
+  if (!delivery) return {skipped: true};
+
+  try {
+    const mentions = ["open", "reminder"].includes(kind) ? await getGroupMentions(sock, group.groupId) : [];
+    const text = ["paid", "refunded"].includes(kind) ? buildBolaoResultText(game) : buildBolaoGroupText(game, kind);
+    const sent = await sock.sendMessage(group.groupId, {text, mentions});
+    await markDeliverySuccess(delivery, sent?.key?.id);
+    return {sent: true};
+  } catch (err) {
+    await markDeliveryFailed(delivery, err);
+    throw err;
+  }
+}
+
+function buildOwnerReviewText(game) {
+  return `Bolao quase abrindo:
+
+${game.title}
+Abre: ${formatDateTime(game.bettingOpensAt)}
+Fecha: ${formatDateTime(game.bettingClosesAt)}
+Link admin: ${buildPanelLink(String(game._id))}
+
+Se precisar cancelar:
+${prefixo || "/"}bolao cancelar ${game.code} motivo`;
+}
+
+function buildResultPromptText(game) {
+  return `Resultado pendente do bolao:
+
+${game.title}
+Codigo: ${game.code}
+Jogo: ${formatDateTime(game.startsAt)}
+
+Quando terminar, mande:
+${prefixo || "/"}bolao resultado ${game.code} 2x1
+
+Depois confira o preview e confirme:
+${prefixo || "/"}bolao pagar ${game.code}`;
+}
+
+async function sendOwnerDelivery(sock, targetId, kind, text, game = null, options = {}) {
+  if (!sock) throw new Error("socket indisponivel");
+  const delivery = await acquireDelivery({game, kind, targetId, dedupeKey: options.dedupeKey});
+  if (!delivery) return {skipped: true};
+
+  try {
+    const sent = await sock.sendMessage(targetId, {text});
+    await markDeliverySuccess(delivery, sent?.key?.id);
+    return {sent: true};
+  } catch (err) {
+    await markDeliveryFailed(delivery, err);
+    throw err;
+  }
+}
+
+async function getCommandStatus(gameRef) {
+  const game = await findGameByRef(gameRef);
+  const [stats, bets] = await Promise.all([
+    getGameStats([game._id]),
+    bolaoBets.find({gameId: game._id}).sort({stake: -1}).limit(8).lean()
+  ]);
+  const stat = stats.get(String(game._id)) || {pool: 0, bets: 0};
+
+  return {
+    game: serializeGame(game, {pool: stat.pool, bets: stat.bets}),
+    bets: bets.map(serializeBet)
+  };
+}
+
+async function getOpenGames() {
+  const now = new Date();
+  return bolaoGames
+    .find({status: "open", bettingClosesAt: {$gt: now}})
+    .sort({bettingClosesAt: 1})
+    .limit(8)
+    .lean();
+}
+
+module.exports = {
+  MIN_BET,
+  buildBolaoGroupText,
+  buildOwnerReviewText,
+  buildPanelLink,
+  buildResultPromptText,
+  cancelGame,
+  cleanText,
+  compactText,
+  confirmPayout,
+  createGame,
+  createResultPreview,
+  formatDateTime,
+  formatMoney,
+  getCommandStatus,
+  getCuratorLids,
+  getEnabledBolaoGroups,
+  getOpenGames,
+  getPanelBolaoGame,
+  httpError,
+  isBolaoAdmin,
+  listPanelBolao,
+  parseGameCreateText,
+  parseScoreText,
+  placeOrUpdateBet,
+  refundActiveBets,
+  sendBolaoGroupDelivery,
+  sendOwnerDelivery,
+  serializeGame,
+  toIso,
+  updateBolaoGroupConfig
+};


### PR DESCRIPTION
## Resumo
- adiciona bolao com jogos, apostas de placar exato e dinheiro virtual reservado no ato da aposta
- cria worker duravel para abrir, lembrar, fechar, pedir resultado e publicar pagamento sem depender de timer em memoria
- adiciona aba Bolao no painel com fluxo mobile/desktop, aposta editavel e controles de dono

## Testes
- node --check nos JS alterados
- require smoke dos modulos novos
- checks puros de parse/mensagem do bolao
- smoke visual desktop/mobile em mock local do painel