### PR TITLE
fix(bolao): estabilizo apostas da yuki

### DIFF
--- a/src/backend/controllers/user/panel.js
+++ b/src/backend/controllers/user/panel.js
@@ -8,6 +8,15 @@ const {
   runGroupAction,
   updateGroupConfig
 } = require("../../services/panelService");
+const {
+  confirmPayout,
+  createGame,
+  createResultPreview,
+  getPanelBolaoGame,
+  listPanelBolao,
+  placeOrUpdateBet,
+  serializeGame
+} = require("../../services/bolaoService");
 
 function getSender(req) {
   const sender = req.user?.sender;
@@ -96,9 +105,87 @@ async function announcementConfirm(req, res) {
   }
 }
 
+async function bolaoHome(req, res) {
+  try {
+    const data = await listPanelBolao(getSender(req));
+    res.status(200).json(data);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoDetails(req, res) {
+  try {
+    const data = await getPanelBolaoGame(getSender(req), req.params.gameId);
+    res.status(200).json(data);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoBet(req, res) {
+  try {
+    assertCsrf(req);
+    const result = await placeOrUpdateBet({
+      gameId: req.params.gameId,
+      sender: getSender(req),
+      homeScore: req.body?.homeScore,
+      awayScore: req.body?.awayScore,
+      amount: req.body?.amount
+    });
+    res.status(200).json(result);
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoCreateGame(req, res) {
+  try {
+    assertCsrf(req);
+    const game = await createGame({
+      homeTeam: req.body?.homeTeam,
+      awayTeam: req.body?.awayTeam,
+      competition: req.body?.competition,
+      startsAt: req.body?.startsAt
+    }, getSender(req));
+    res.status(201).json({game: serializeGame(game)});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoResultPreview(req, res) {
+  try {
+    assertCsrf(req);
+    const game = await createResultPreview(req.params.gameId, getSender(req), {
+      homeScore: req.body?.homeScore,
+      awayScore: req.body?.awayScore
+    });
+    res.status(200).json({game});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
+async function bolaoPayoutConfirm(req, res) {
+  try {
+    assertCsrf(req);
+    const game = await confirmPayout(req.params.gameId, getSender(req));
+    res.status(200).json({game});
+  } catch (err) {
+    sendError(res, err);
+  }
+}
+
 module.exports = {
   announcementConfirm,
   announcementPreview,
+  bolaoBet,
+  bolaoCreateGame,
+  bolaoDetails,
+  bolaoHome,
+  bolaoPayoutConfirm,
+  bolaoResultPreview,
   groupAction,
   groupDetails,
   listGroups,

--- a/src/backend/public/painel/app.js
+++ b/src/backend/public/painel/app.js
@@ -5,6 +5,7 @@ const tabsEl = document.getElementById("tabs");
 
 const views = {
   profile: document.getElementById("viewProfile"),
+  bolao: document.getElementById("viewBolao"),
   groups: document.getElementById("viewGroups"),
   config: document.getElementById("viewConfig"),
   moderation: document.getElementById("viewModeration"),
@@ -22,11 +23,21 @@ const state = {
   selectedGroupId: null,
   selectedGroup: null,
   groupDetails: null,
-  announcementPreview: null
+  announcementPreview: null,
+  bolao: {
+    loading: false,
+    canManage: false,
+    balance: 0,
+    games: [],
+    selectedGameId: null,
+    selectedGame: null,
+    details: null
+  }
 };
 
 const tabDefs = [
   {id: "profile", label: "Perfil"},
+  {id: "bolao", label: "Bolao"},
   {id: "groups", label: "Grupos"},
   {id: "config", label: "Config", needsGroup: true},
   {id: "moderation", label: "Moderacao", needsGroup: true},
@@ -78,6 +89,25 @@ function formatDate(value) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "Sem data";
   return date.toLocaleDateString("pt-BR");
+}
+
+function formatDateTime(value) {
+  if (!value) return "Sem data";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Sem data";
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function toDateTimeLocal(value) {
+  const date = value ? new Date(value) : new Date(Date.now() + 3 * 60 * 60 * 1000);
+  if (Number.isNaN(date.getTime())) return "";
+  const offset = date.getTimezoneOffset() * 60000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
 function canManageSelectedGroup() {
@@ -215,6 +245,43 @@ async function loadGroupDetails(force = false) {
   return state.groupDetails;
 }
 
+function selectBolaoState(gameId) {
+  const games = state.bolao.games || [];
+  if (gameId) {
+    const match = games.find((game) => game.id === gameId || game.code === gameId);
+    if (match) state.bolao.selectedGameId = match.id;
+  }
+
+  if (!state.bolao.selectedGameId || !games.some((game) => game.id === state.bolao.selectedGameId)) {
+    const open = games.find((game) => game.status === "open");
+    state.bolao.selectedGameId = (open || games[0])?.id || null;
+  }
+
+  state.bolao.selectedGame = games.find((game) => game.id === state.bolao.selectedGameId) || null;
+}
+
+async function loadBolao(preferredGameId = null) {
+  state.bolao.loading = true;
+  const data = await api("/auth/panel/bolao");
+  state.bolao.canManage = !!data.canManage;
+  state.bolao.balance = data.balance || 0;
+  state.bolao.games = data.games || [];
+  selectBolaoState(preferredGameId);
+  state.bolao.loading = false;
+
+  if (state.bolao.selectedGameId) {
+    state.bolao.details = await api(`/auth/panel/bolao/${encodeURIComponent(state.bolao.selectedGameId)}`);
+    if (state.bolao.details?.game) {
+      const game = state.bolao.details.game;
+      const index = state.bolao.games.findIndex((item) => item.id === game.id);
+      if (index >= 0) state.bolao.games[index] = game;
+      state.bolao.selectedGame = game;
+    }
+  } else {
+    state.bolao.details = null;
+  }
+}
+
 function renderShell() {
   document.getElementById("roleBadge").textContent = state.user.roleLabel || "Usuario";
   document.getElementById("roleBadge").className = `role-badge ${state.user.role || "user"}`;
@@ -286,6 +353,124 @@ function accessCopy(role, managedCount) {
   if (role === "subowner") return "Staff operacional. Acoes ficam abaixo dos donos reais.";
   if (managedCount) return "Admin de grupo com acoes liberadas nos grupos onde voce ainda e admin.";
   return "Seu painel mostra dados pessoais e status nos grupos.";
+}
+
+function renderBolao() {
+  if (state.bolao.loading && !state.bolao.games.length) {
+    views.bolao.innerHTML = loadingPanel("Bolao");
+    return;
+  }
+
+  const games = state.bolao.games || [];
+  const selected = state.bolao.selectedGame;
+  const details = state.bolao.details;
+
+  views.bolao.innerHTML = `
+    <section class="bolao-panel liquid">
+      <div class="section-head">
+        <div>
+          <p class="eyebrow">Moedas em campo</p>
+          <h2>Bolao</h2>
+          <p class="muted">Apostas de placar exato. Link publico so abre esta aba; a sessao continua protegida pelo /painel.</p>
+        </div>
+        <span class="count">${formatMoney(state.bolao.balance)} moedas</span>
+      </div>
+
+      <div class="bolao-grid">
+        <div class="bolao-list">
+          ${games.length ? games.map(renderBolaoGame).join("") : '<p class="empty">Nenhum jogo cadastrado.</p>'}
+        </div>
+        <div class="bolao-focus">
+          ${selected ? renderBolaoFocus(selected, details) : '<p class="empty">Selecione um jogo.</p>'}
+        </div>
+      </div>
+    </section>
+    ${state.bolao.canManage ? renderBolaoAdmin(selected) : ""}
+  `;
+}
+
+function renderBolaoGame(game) {
+  return `
+    <button class="bolao-game ${game.id === state.bolao.selectedGameId ? "active" : ""}" data-bolao-game="${escapeHtml(game.id)}" type="button">
+      <span>
+        <strong>${escapeHtml(game.title)}</strong>
+        <small>${escapeHtml(game.code)} · fecha ${formatDateTime(game.closesAt)}</small>
+      </span>
+      <em>${escapeHtml(game.statusLabel)}</em>
+    </button>
+  `;
+}
+
+function renderBolaoFocus(game, details) {
+  const userBet = details?.game?.userBet || game.userBet;
+  const bets = details?.bets || [];
+  return `
+    <div class="bolao-match">
+      <p class="eyebrow">${escapeHtml(game.competition || "Copa")}</p>
+      <h3>${escapeHtml(game.homeTeam)} x ${escapeHtml(game.awayTeam)}</h3>
+      <div class="status-matrix">
+        <span>${escapeHtml(game.statusLabel)}</span>
+        <span>${formatDateTime(game.startsAt)}</span>
+        <span>Pool ${formatMoney(game.pool || 0)}</span>
+        <span>${formatNumber(game.bets || 0)} apostas</span>
+      </div>
+      ${renderBolaoBetForm(game, userBet)}
+      <div class="bolao-bets">
+        ${bets.length ? bets.slice(0, 12).map((bet) => `
+          <article class="bolao-bet-row">
+            <span>${escapeHtml(bet.name || "Sem nome")}</span>
+            <strong>${escapeHtml(bet.score || "oculto")}</strong>
+            <em>${formatMoney(bet.paidAmount || bet.stake || 0)}</em>
+          </article>
+        `).join("") : '<p class="empty">As apostas aparecem aqui quando estiverem liberadas.</p>'}
+      </div>
+    </div>
+  `;
+}
+
+function renderBolaoBetForm(game, userBet) {
+  const disabled = !game.canBet;
+  return `
+    <form id="bolaoBetForm" class="bolao-form" data-game-id="${escapeHtml(game.id)}">
+      <label><span>${escapeHtml(game.homeTeam)}</span><input id="bolaoHomeScore" type="number" min="0" max="30" value="${escapeHtml(userBet?.homeScore ?? "")}" ${disabled ? "disabled" : ""}></label>
+      <label><span>${escapeHtml(game.awayTeam)}</span><input id="bolaoAwayScore" type="number" min="0" max="30" value="${escapeHtml(userBet?.awayScore ?? "")}" ${disabled ? "disabled" : ""}></label>
+      <label><span>Moedas</span><input id="bolaoStake" type="number" min="${escapeHtml(game.minBet || 100)}" value="${escapeHtml(userBet?.stake || game.minBet || 100)}" ${disabled ? "disabled" : ""}></label>
+      <button class="primary-button" type="submit" ${disabled ? "disabled" : ""}>${userBet ? "Atualizar" : "Apostar"}</button>
+      <p id="bolaoBetMessage" class="form-message">${disabled ? "Apostas fechadas." : ""}</p>
+    </form>
+  `;
+}
+
+function renderBolaoAdmin(selected) {
+  const resultEnabled = selected && ["closed", "result_preview"].includes(selected.status);
+  return `
+    <section class="bolao-admin-grid">
+      <form id="bolaoCreateForm" class="liquid quiet-panel">
+        <p class="eyebrow">Dono</p>
+        <h3>Criar jogo</h3>
+        <div class="bolao-form admin">
+          <label><span>Mandante</span><input id="bolaoCreateHome" required placeholder="Brasil"></label>
+          <label><span>Visitante</span><input id="bolaoCreateAway" required placeholder="Argentina"></label>
+          <label><span>Data</span><input id="bolaoCreateStart" type="datetime-local" required value="${escapeHtml(toDateTimeLocal())}"></label>
+          <label><span>Competicao</span><input id="bolaoCreateCompetition" value="Copa do Mundo"></label>
+        </div>
+        <button class="primary-button" type="submit">Criar</button>
+        <p id="bolaoCreateMessage" class="form-message"></p>
+      </form>
+
+      <form id="bolaoResultForm" class="liquid quiet-panel" data-game-id="${escapeHtml(selected?.id || "")}">
+        <p class="eyebrow">Resultado</p>
+        <h3>${selected ? escapeHtml(selected.title) : "Selecione um jogo"}</h3>
+        <div class="bolao-form result">
+          <label><span>Casa</span><input id="bolaoResultHome" type="number" min="0" max="30" ${resultEnabled ? "" : "disabled"}></label>
+          <label><span>Fora</span><input id="bolaoResultAway" type="number" min="0" max="30" ${resultEnabled ? "" : "disabled"}></label>
+          <button class="ghost-button" type="submit" ${resultEnabled ? "" : "disabled"}>Preview</button>
+          <button id="bolaoConfirmPayout" class="danger-button" data-game-id="${escapeHtml(selected?.id || "")}" type="button" ${selected?.status === "result_preview" ? "" : "disabled"}>Pagar</button>
+        </div>
+        <p id="bolaoResultMessage" class="form-message"></p>
+      </form>
+    </section>
+  `;
 }
 
 function renderGroups() {
@@ -595,6 +780,7 @@ function emptyPanel(title, text) {
 function renderAll() {
   renderShell();
   renderProfile();
+  renderBolao();
   renderGroups();
   renderConfig();
   renderModeration();
@@ -608,6 +794,11 @@ function renderAll() {
 async function switchTab(tabId) {
   if (!visibleTabs().some((tab) => tab.id === tabId)) return;
   state.activeTab = tabId;
+
+  if (tabId === "bolao") {
+    renderAll();
+    await loadBolao();
+  }
 
   if (["config", "moderation"].includes(tabId) && canManageSelectedGroup()) {
     renderAll();
@@ -627,11 +818,19 @@ async function selectGroup(groupId) {
   renderAll();
 }
 
+async function selectBolaoGame(gameId) {
+  selectBolaoState(gameId);
+  state.bolao.details = null;
+  renderAll();
+  await loadBolao(state.bolao.selectedGameId);
+  renderAll();
+}
+
 async function saveConfig(event) {
   event.preventDefault();
   if (!state.groupDetails) return;
 
-  const form = event.currentTarget;
+  const form = event.target;
   const body = {
     prefixo: form.querySelector("#prefixInput").value,
     welcome: form.querySelector('[name="welcome"]').checked,
@@ -731,6 +930,84 @@ async function confirmAnnouncement() {
   setStatus("Anuncio iniciado", "ok");
 }
 
+async function submitBolaoBet(event) {
+  event.preventDefault();
+  const form = event.target;
+  const gameId = form.dataset.gameId;
+  const message = document.getElementById("bolaoBetMessage");
+  if (message) message.textContent = "Salvando...";
+
+  await api(`/auth/panel/bolao/${encodeURIComponent(gameId)}/bets`, {
+    method: "POST",
+    mutate: true,
+    body: {
+      homeScore: Number(document.getElementById("bolaoHomeScore").value),
+      awayScore: Number(document.getElementById("bolaoAwayScore").value),
+      amount: Number(document.getElementById("bolaoStake").value)
+    }
+  });
+
+  await loadBolao(gameId);
+  renderAll();
+  setStatus("Aposta salva", "ok");
+}
+
+async function submitBolaoCreate(event) {
+  event.preventDefault();
+  const message = document.getElementById("bolaoCreateMessage");
+  if (message) message.textContent = "Criando...";
+
+  const created = await api("/auth/panel/bolao/games", {
+    method: "POST",
+    mutate: true,
+    body: {
+      homeTeam: document.getElementById("bolaoCreateHome").value,
+      awayTeam: document.getElementById("bolaoCreateAway").value,
+      startsAt: document.getElementById("bolaoCreateStart").value.replace("T", " "),
+      competition: document.getElementById("bolaoCreateCompetition").value
+    }
+  });
+
+  await loadBolao(created.game?.id);
+  renderAll();
+  setStatus("Bolao criado", "ok");
+}
+
+async function submitBolaoResult(event) {
+  event.preventDefault();
+  const form = event.target;
+  const gameId = form.dataset.gameId;
+  if (!gameId) return;
+
+  await api(`/auth/panel/bolao/${encodeURIComponent(gameId)}/result`, {
+    method: "POST",
+    mutate: true,
+    body: {
+      homeScore: Number(document.getElementById("bolaoResultHome").value),
+      awayScore: Number(document.getElementById("bolaoResultAway").value)
+    }
+  });
+
+  await loadBolao(gameId);
+  renderAll();
+  setStatus("Preview pronto", "ok");
+}
+
+async function confirmBolaoPayout(gameId) {
+  const ok = await confirmAction("Pagar bolao", "Confirmar pagamento ou reembolso deste jogo?");
+  if (!ok) return;
+
+  await api(`/auth/panel/bolao/${encodeURIComponent(gameId)}/payout`, {
+    method: "POST",
+    mutate: true,
+    body: {}
+  });
+
+  await loadBolao(gameId);
+  renderAll();
+  setStatus("Bolao pago", "ok");
+}
+
 document.addEventListener("click", async (event) => {
   try {
     const tabButton = event.target.closest("[data-tab]");
@@ -742,6 +1019,12 @@ document.addEventListener("click", async (event) => {
     const groupButton = event.target.closest("[data-group-id]");
     if (groupButton) {
       await selectGroup(groupButton.dataset.groupId);
+      return;
+    }
+
+    const bolaoButton = event.target.closest("[data-bolao-game]");
+    if (bolaoButton) {
+      await selectBolaoGame(bolaoButton.dataset.bolaoGame);
       return;
     }
 
@@ -759,6 +1042,10 @@ document.addEventListener("click", async (event) => {
 
     if (event.target.id === "confirmAnnouncement") {
       await confirmAnnouncement();
+    }
+
+    if (event.target.id === "bolaoConfirmPayout") {
+      await confirmBolaoPayout(event.target.dataset.gameId);
     }
   } catch (err) {
     setStatus("Erro", "error");
@@ -781,6 +1068,18 @@ document.addEventListener("submit", async (event) => {
     if (event.target.id === "announcementForm") {
       await createAnnouncement(event);
     }
+
+    if (event.target.id === "bolaoBetForm") {
+      await submitBolaoBet(event);
+    }
+
+    if (event.target.id === "bolaoCreateForm") {
+      await submitBolaoCreate(event);
+    }
+
+    if (event.target.id === "bolaoResultForm") {
+      await submitBolaoResult(event);
+    }
   } catch (err) {
     setStatus("Erro", "error");
     const message = event.target.querySelector(".form-message");
@@ -792,6 +1091,8 @@ async function boot() {
   try {
     const params = new URLSearchParams(window.location.search);
     const token = params.get("token");
+    const bolaoHash = window.location.hash.match(/^#bolao\/([^?#]+)/);
+    const bolaoGameId = bolaoHash ? decodeURIComponent(bolaoHash[1]) : null;
 
     if (token) {
       setStatus("Entrando...");
@@ -800,7 +1101,18 @@ async function boot() {
 
     setStatus("Carregando...");
     await loadMe();
+    if (bolaoGameId) {
+      state.activeTab = "bolao";
+      await loadBolao(bolaoGameId);
+    }
     renderAll();
+    if (!bolaoGameId) {
+      loadBolao()
+        .then(() => renderAll())
+        .catch((err) => {
+          console.warn("Nao foi possivel carregar bolao:", err);
+        });
+    }
     loadManageableGroups()
       .then(() => renderAll())
       .catch((err) => {

--- a/src/backend/public/painel/index.html
+++ b/src/backend/public/painel/index.html
@@ -32,6 +32,7 @@
       <nav id="tabs" class="tab-rail liquid" aria-label="Areas do painel"></nav>
 
       <section id="viewProfile" class="view active"></section>
+      <section id="viewBolao" class="view"></section>
       <section id="viewGroups" class="view"></section>
       <section id="viewConfig" class="view"></section>
       <section id="viewModeration" class="view"></section>

--- a/src/backend/public/painel/styles.css
+++ b/src/backend/public/painel/styles.css
@@ -595,6 +595,154 @@ h3 {
   border-bottom: 1px solid rgba(255, 255, 255, .08);
 }
 
+button:disabled {
+  cursor: not-allowed;
+  opacity: .55;
+}
+
+.bolao-panel {
+  padding: 24px;
+}
+
+.bolao-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, .8fr) minmax(0, 1.2fr);
+  gap: 12px;
+}
+
+.bolao-list {
+  display: grid;
+  align-content: start;
+  gap: 10px;
+}
+
+.bolao-game {
+  display: flex;
+  width: 100%;
+  min-height: 78px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  color: var(--text);
+  text-align: left;
+  background: rgba(4, 14, 18, .58);
+}
+
+.bolao-game.active {
+  border-color: rgba(255, 209, 102, .52);
+  background:
+    linear-gradient(135deg, rgba(32, 95, 63, .55), rgba(11, 41, 54, .6)),
+    rgba(4, 14, 18, .58);
+}
+
+.bolao-game strong,
+.bolao-game small {
+  display: block;
+}
+
+.bolao-game small {
+  margin-top: 4px;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+}
+
+.bolao-game em {
+  flex: 0 0 auto;
+  min-height: 30px;
+  padding: 6px 10px;
+  border: 1px solid rgba(101, 240, 174, .34);
+  border-radius: 999px;
+  color: var(--ok);
+  font-size: 12px;
+  font-style: normal;
+  background: rgba(2, 10, 13, .58);
+}
+
+.bolao-focus {
+  min-width: 0;
+  padding: 18px;
+  border: 1px solid rgba(255, 255, 255, .1);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(135deg, rgba(101, 240, 174, .08), rgba(118, 220, 255, .04)),
+    rgba(2, 10, 13, .46);
+}
+
+.bolao-match h3 {
+  font-size: clamp(28px, 4vw, 48px);
+}
+
+.bolao-form {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr)) auto;
+  gap: 10px;
+  align-items: end;
+  margin-top: 14px;
+}
+
+.bolao-form.admin,
+.bolao-form.result {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.bolao-form label {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+}
+
+.bolao-form input {
+  width: 100%;
+  height: 42px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 0 12px;
+  color: var(--text);
+  outline: none;
+  background: rgba(1, 8, 10, .7);
+}
+
+.bolao-form .form-message {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.bolao-bets {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.bolao-bet-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 80px 100px;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, .08);
+}
+
+.bolao-bet-row span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bolao-bet-row em {
+  color: var(--warn);
+  font-style: normal;
+  text-align: right;
+}
+
+.bolao-admin-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, .8fr);
+  gap: 12px;
+  margin-top: 12px;
+}
+
 .empty {
   color: var(--muted);
 }
@@ -653,8 +801,16 @@ h3 {
   .workspace-grid,
   .announcement-grid,
   .ops-grid,
-  .moderation-layout {
+  .moderation-layout,
+  .bolao-grid,
+  .bolao-admin-grid {
     grid-template-columns: 1fr;
+  }
+
+  .bolao-form,
+  .bolao-form.admin,
+  .bolao-form.result {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -703,8 +859,29 @@ h3 {
   }
 
   .member-row,
-  .log-row {
+  .log-row,
+  .bolao-bet-row {
     grid-template-columns: 1fr;
+  }
+
+  .bolao-panel,
+  .bolao-focus {
+    padding: 18px;
+  }
+
+  .bolao-game {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .bolao-form,
+  .bolao-form.admin,
+  .bolao-form.result {
+    grid-template-columns: 1fr;
+  }
+
+  .bolao-bet-row em {
+    text-align: left;
   }
 
   .member-actions {

--- a/src/backend/routes/user.js
+++ b/src/backend/routes/user.js
@@ -15,6 +15,18 @@ router.get("/user", user_info);
 
 router.get("/me", isLogin, me);
 
+router.get("/panel/bolao", isLogin, panel.bolaoHome);
+
+router.post("/panel/bolao/games", isLogin, panel.bolaoCreateGame);
+
+router.get("/panel/bolao/:gameId", isLogin, panel.bolaoDetails);
+
+router.post("/panel/bolao/:gameId/bets", isLogin, panel.bolaoBet);
+
+router.post("/panel/bolao/:gameId/result", isLogin, panel.bolaoResultPreview);
+
+router.post("/panel/bolao/:gameId/payout", isLogin, panel.bolaoPayoutConfirm);
+
 router.get("/panel/groups/:groupId", isLogin, panel.groupDetails);
 
 router.get("/panel/groups", isLogin, panel.listGroups);

--- a/src/commands/donos/testebolao.js
+++ b/src/commands/donos/testebolao.js
@@ -1,0 +1,50 @@
+const { createGame, formatDateTime, isBolaoAdmin } = require("../../services/bolaoService");
+
+module.exports = {
+  name: "testebolao",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      if (!(await isBolaoAdmin(sender))) {
+        await sock.sendMessage(from, {text: "So dono real da Yuki pode rodar teste de bolao."}, {quoted: msg});
+        return;
+      }
+
+      if (!from.endsWith("@g.us")) {
+        await sock.sendMessage(from, {text: "Use /testebolao dentro do grupo de teste."}, {quoted: msg});
+        return;
+      }
+
+      const now = Date.now();
+      const game = await createGame({
+        homeTeam: "Brasil Teste",
+        awayTeam: "Yuki FC",
+        competition: "Teste interno",
+        startsAt: new Date(now + 15 * 60 * 1000),
+        closesAt: new Date(now + 10 * 60 * 1000),
+        groupId: from,
+        minBet: 100
+      }, sender, {testMode: true});
+
+      await sock.sendMessage(from, {
+        text: `Teste criado.
+
+Codigo: ${game.code}
+Fecha: ${formatDateTime(game.closesAt)}
+
+Postar chamada:
+/bolao anunciar ${game.code}
+
+Apostar:
+/bolao apostar ${game.code} 2x1 100
+
+Encerrar:
+/bolao fechar ${game.code}
+/bolao resultado ${game.code} 2x1
+/bolao pagar ${game.code}`
+      }, {quoted: msg});
+    } catch (err) {
+      await sock.sendMessage(from, {text: err?.status ? err.message : (erros_prontos || "Falha no teste do bolao.")}, {quoted: msg});
+      if (!err?.status) console.error("Erro no /testebolao:", err);
+    }
+  }
+};

--- a/src/commands/donos/testebolaoAcento.js
+++ b/src/commands/donos/testebolaoAcento.js
@@ -1,0 +1,6 @@
+const testebolao = require("./testebolao");
+
+module.exports = {
+  ...testebolao,
+  name: "testebolão"
+};

--- a/src/commands/economia/bolao.js
+++ b/src/commands/economia/bolao.js
@@ -1,0 +1,216 @@
+const { prefixo } = require("../../config");
+const {
+  announceGame,
+  cancelGame,
+  closeGame,
+  confirmPayout,
+  createGame,
+  createResultPreview,
+  formatDateTime,
+  formatMoney,
+  isBolaoAdmin,
+  listPanelBolao,
+  parseGameCreateText,
+  parseScoreText,
+  placeOrUpdateBet
+} = require("../../services/bolaoService");
+
+function pfx() {
+  return prefixo || "/";
+}
+
+async function help(sock, msg, from) {
+  await sock.sendMessage(from, {
+    text: `*Bolao da Yuki*
+
+Usuario:
+${pfx()}bolao
+${pfx()}bolao apostar CODIGO 2x1 100
+
+Dono:
+${pfx()}bolao criar Brasil x Argentina | 2026-06-14 16:00 | Copa
+${pfx()}bolao anunciar CODIGO
+${pfx()}bolao fechar CODIGO
+${pfx()}bolao resultado CODIGO 2x1
+${pfx()}bolao pagar CODIGO
+${pfx()}bolao cancelar CODIGO motivo`
+  }, {quoted: msg});
+}
+
+function previewText(game) {
+  const preview = game.payoutPreview || {};
+  if (!preview.totalBets) {
+    return `Preview gerado para ${game.title}, mas nao tem aposta ativa.`;
+  }
+
+  if (!preview.winnerCount) {
+    return `*Preview do bolao*
+
+${game.title}: ${game.result?.score}
+Apostas: ${preview.totalBets}
+Pool: ${formatMoney(preview.pool)}
+
+Ninguem cravou. Confirmando, a Yuki reembolsa geral.`;
+  }
+
+  const winners = (preview.winners || [])
+    .slice(0, 8)
+    .map((winner, index) => `${index + 1}. ${winner.name} - +${formatMoney(winner.total)}`)
+    .join("\n");
+
+  return `*Preview do bolao*
+
+${game.title}: ${game.result?.score}
+Apostas: ${preview.totalBets}
+Pool: ${formatMoney(preview.pool)}
+Ganhadores: ${preview.winnerCount}
+Pagamento: ${formatMoney(preview.totalPayout)}
+
+${winners}`;
+}
+
+async function listGames(sock, msg, from, sender) {
+  const data = await listPanelBolao(sender);
+  const games = data.games.slice(0, 8);
+  if (!games.length) {
+    await sock.sendMessage(from, {text: "Nenhum bolao cadastrado agora."}, {quoted: msg});
+    return;
+  }
+
+  await sock.sendMessage(from, {
+    text: games.map((game) =>
+      `${game.code} - ${game.title}\nStatus: ${game.statusLabel}\nFecha: ${formatDateTime(game.closesAt)}\nPool: ${formatMoney(game.pool || 0)}`
+    ).join("\n\n")
+  }, {quoted: msg});
+}
+
+async function handleCreate(sock, msg, from, args, sender) {
+  if (!(await isBolaoAdmin(sender))) {
+    await sock.sendMessage(from, {text: "So dono real da Yuki pode criar bolao."}, {quoted: msg});
+    return;
+  }
+
+  const input = parseGameCreateText(args.slice(1).join(" "));
+  const game = await createGame({...input, groupId: from.endsWith("@g.us") ? from : null}, sender);
+  await sock.sendMessage(from, {
+    text: `Bolao criado.
+
+Codigo: ${game.code}
+Jogo: ${game.title}
+Fecha: ${formatDateTime(game.closesAt)}
+
+Para postar no grupo:
+${pfx()}bolao anunciar ${game.code}`
+  }, {quoted: msg});
+}
+
+async function handleAnnounce(sock, msg, from, args, sender) {
+  const code = args[1];
+  if (!code) {
+    await sock.sendMessage(from, {text: `Use: ${pfx()}bolao anunciar CODIGO`}, {quoted: msg});
+    return;
+  }
+
+  await announceGame(sock, code, from, sender);
+}
+
+async function handleBet(sock, msg, from, args, sender) {
+  const code = args[1];
+  const scoreText = args[2];
+  const amount = Number(args[3]);
+
+  if (!code || !scoreText || !amount) {
+    await sock.sendMessage(from, {text: `Use: ${pfx()}bolao apostar CODIGO 2x1 100`}, {quoted: msg});
+    return;
+  }
+
+  const score = parseScoreText(scoreText);
+  const result = await placeOrUpdateBet({
+    gameId: code,
+    sender,
+    name: msg.pushName || "Sem nome",
+    groupId: from.endsWith("@g.us") ? from : null,
+    homeScore: score.home,
+    awayScore: score.away,
+    amount
+  });
+
+  await sock.sendMessage(from, {
+    text: `Bilhete salvo.
+
+${result.game.title}
+Placar: ${result.bet.score}
+Valor: ${formatMoney(result.bet.stake)} moedas
+
+Da para editar ate fechar, usando o mesmo comando.`
+  }, {quoted: msg});
+}
+
+async function handleClose(sock, msg, from, args, sender) {
+  const game = await closeGame(args[1], sender);
+  await sock.sendMessage(from, {text: `Bolao fechado: ${game.title}`}, {quoted: msg});
+}
+
+async function handleResult(sock, msg, from, args, sender) {
+  const code = args[1];
+  const score = args[2];
+  if (!code || !score) {
+    await sock.sendMessage(from, {text: `Use: ${pfx()}bolao resultado CODIGO 2x1`}, {quoted: msg});
+    return;
+  }
+
+  const game = await createResultPreview(code, sender, score);
+  await sock.sendMessage(from, {
+    text: `${previewText(game)}
+
+Se estiver certo:
+${pfx()}bolao pagar ${game.code}`
+  }, {quoted: msg});
+}
+
+async function handlePay(sock, msg, from, args, sender) {
+  const game = await confirmPayout(args[1], sender);
+  await sock.sendMessage(from, {
+    text: `Bolao encerrado.
+
+${game.title}
+Status: ${game.statusLabel}
+Pool: ${formatMoney(game.payoutPreview?.pool || 0)}
+Ganhadores: ${game.payoutPreview?.winnerCount || 0}`
+  }, {quoted: msg});
+}
+
+async function handleCancel(sock, msg, from, args, sender) {
+  const code = args[1];
+  const reason = args.slice(2).join(" ") || "cancelado pelo dono";
+  const result = await cancelGame(code, sender, reason);
+  await sock.sendMessage(from, {
+    text: `Bolao cancelado.
+
+${result.game.title}
+Reembolsos: ${result.refunded}`
+  }, {quoted: msg});
+}
+
+module.exports = {
+  name: "bolao",
+  async execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender) {
+    try {
+      const action = String(args[0] || "listar").toLowerCase();
+      if (["help", "ajuda"].includes(action)) return help(sock, msg, from);
+      if (["listar", "lista", "status"].includes(action)) return listGames(sock, msg, from, sender);
+      if (action === "criar") return handleCreate(sock, msg, from, args, sender);
+      if (["anunciar", "abrir"].includes(action)) return handleAnnounce(sock, msg, from, args, sender);
+      if (["apostar", "aposta"].includes(action)) return handleBet(sock, msg, from, args, sender);
+      if (action === "fechar") return handleClose(sock, msg, from, args, sender);
+      if (["resultado", "result"].includes(action)) return handleResult(sock, msg, from, args, sender);
+      if (["pagar", "confirmar"].includes(action)) return handlePay(sock, msg, from, args, sender);
+      if (["cancelar", "cancel"].includes(action)) return handleCancel(sock, msg, from, args, sender);
+      return help(sock, msg, from);
+    } catch (err) {
+      const status = err?.status || 500;
+      await sock.sendMessage(from, {text: status < 500 ? err.message : (erros_prontos || "Deu ruim no bolao.")}, {quoted: msg});
+      if (status >= 500) console.error("Erro no /bolao:", err);
+    }
+  }
+};

--- a/src/commands/economia/bolaoAcento.js
+++ b/src/commands/economia/bolaoAcento.js
@@ -1,0 +1,6 @@
+const bolao = require("./bolao");
+
+module.exports = {
+  ...bolao,
+  name: "bolão"
+};

--- a/src/database/models/bolao.js
+++ b/src/database/models/bolao.js
@@ -1,0 +1,87 @@
+const mongoose = require("mongoose");
+
+const gameSchema = new mongoose.Schema({
+  code: {type: String, required: true, unique: true, index: true},
+  title: {type: String, required: true},
+  competition: {type: String, default: "Copa do Mundo"},
+  homeTeam: {type: String, required: true},
+  awayTeam: {type: String, required: true},
+  startsAt: {type: Date, required: true, index: true},
+  closesAt: {type: Date, required: true, index: true},
+  status: {
+    type: String,
+    enum: ["open", "closed", "result_preview", "paid", "refunded", "cancelled"],
+    default: "open",
+    index: true
+  },
+  createdBy: {type: String, required: true, index: true},
+  groupId: {type: String, default: null, index: true},
+  testMode: {type: Boolean, default: false, index: true},
+  minBet: {type: Number, default: 100},
+  result: {
+    homeScore: {type: Number, default: null},
+    awayScore: {type: Number, default: null},
+    setBy: {type: String, default: null},
+    setAt: {type: Date, default: null}
+  },
+  payoutPreview: {
+    pool: {type: Number, default: 0},
+    totalBets: {type: Number, default: 0},
+    winnerCount: {type: Number, default: 0},
+    totalPayout: {type: Number, default: 0},
+    winners: {type: [Object], default: []},
+    refunds: {type: [Object], default: []},
+    generatedAt: {type: Date, default: null}
+  },
+  paidAt: {type: Date, default: null},
+  cancelledAt: {type: Date, default: null},
+  cancelReason: {type: String, default: null}
+}, {timestamps: true});
+
+gameSchema.index({status: 1, startsAt: 1});
+
+const betSchema = new mongoose.Schema({
+  gameId: {type: mongoose.Schema.Types.ObjectId, required: true, index: true},
+  gameCode: {type: String, required: true, index: true},
+  userLid: {type: String, required: true, index: true},
+  name: {type: String, default: "Sem nome"},
+  groupId: {type: String, default: null, index: true},
+  homeScore: {type: Number, required: true},
+  awayScore: {type: Number, required: true},
+  stake: {type: Number, required: true},
+  status: {
+    type: String,
+    enum: ["active", "paid", "lost", "refunded", "cancelled"],
+    default: "active",
+    index: true
+  },
+  paidAmount: {type: Number, default: 0},
+  revision: {type: Number, default: 0},
+  placedAt: {type: Date, default: Date.now},
+  updatedAt: {type: Date, default: Date.now}
+});
+
+betSchema.index({gameId: 1, userLid: 1}, {unique: true});
+betSchema.index({gameId: 1, status: 1});
+
+const ledgerSchema = new mongoose.Schema({
+  transactionId: {type: String, required: true, unique: true, index: true},
+  gameId: {type: mongoose.Schema.Types.ObjectId, required: true, index: true},
+  gameCode: {type: String, required: true, index: true},
+  userLid: {type: String, required: true, index: true},
+  type: {type: String, required: true, index: true},
+  amount: {type: Number, required: true},
+  status: {type: String, enum: ["applied", "failed"], default: "applied", index: true},
+  meta: {type: Object, default: {}},
+  createdAt: {type: Date, default: Date.now, index: true}
+});
+
+const bolaoGames = mongoose.models.bolaoGame || mongoose.model("bolaoGame", gameSchema);
+const bolaoBets = mongoose.models.bolaoBet || mongoose.model("bolaoBet", betSchema);
+const bolaoLedgers = mongoose.models.bolaoLedger || mongoose.model("bolaoLedger", ledgerSchema);
+
+module.exports = {
+  bolaoBets,
+  bolaoGames,
+  bolaoLedgers
+};

--- a/src/services/bolaoService.js
+++ b/src/services/bolaoService.js
@@ -1,0 +1,599 @@
+const crypto = require("crypto");
+const mongoose = require("mongoose");
+const { bolaoBets, bolaoGames, bolaoLedgers } = require("../database/models/bolao");
+const { users } = require("../database/models/users");
+const { prefixo } = require("../config");
+const { ensureUser, getOwnerLevelCached, updateUserAndCache } = require("../utils/dbHelpers");
+const { normalizeUserLid } = require("../utils/normalizeUserLid");
+
+const MIN_BET = 100;
+const DEFAULT_CLOSE_BEFORE_MS = 10 * 60 * 1000;
+
+function httpError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  return error;
+}
+
+function cleanText(value, fallback = "") {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  return text || fallback;
+}
+
+function toIso(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function toObjectId(value) {
+  const raw = String(value || "");
+  return mongoose.Types.ObjectId.isValid(raw) ? new mongoose.Types.ObjectId(raw) : null;
+}
+
+function stripAccents(value) {
+  return String(value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "");
+}
+
+function slug(value) {
+  return stripAccents(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 20) || "jogo";
+}
+
+function parseLocalDateTime(value) {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
+
+  const text = String(value || "").trim();
+  const match = text.match(/^(\d{4})-(\d{2})-(\d{2})(?:[ T])(\d{2}):(\d{2})$/);
+  if (!match) throw httpError(400, "data invalida. Use YYYY-MM-DD HH:mm.");
+
+  const [, year, month, day, hour, minute] = match.map(Number);
+  const date = new Date(year, month - 1, day, hour, minute, 0, 0);
+  if (Number.isNaN(date.getTime())) throw httpError(400, "data invalida.");
+  return date;
+}
+
+function parseScoreText(value) {
+  const match = String(value || "").trim().match(/^(\d{1,2})\s*[xX:-]\s*(\d{1,2})$/);
+  if (!match) throw httpError(400, "placar invalido. Use 2x1.");
+  return normalizeScore(match[1], match[2]);
+}
+
+function normalizeScore(homeScore, awayScore) {
+  const home = Number(homeScore);
+  const away = Number(awayScore);
+  if (!Number.isInteger(home) || !Number.isInteger(away) || home < 0 || away < 0 || home > 30 || away > 30) {
+    throw httpError(400, "placar invalido.");
+  }
+  return {home, away};
+}
+
+function parseGameCreateText(text) {
+  const parts = String(text || "").split("|").map((part) => part.trim()).filter(Boolean);
+  if (parts.length < 2) {
+    throw httpError(400, "use: /bolao criar Brasil x Argentina | 2026-06-14 16:00 | Copa");
+  }
+
+  const teams = parts[0].split(/\s+(?:x|vs|versus)\s+/i).map((part) => cleanText(part));
+  if (teams.length !== 2 || !teams[0] || !teams[1]) {
+    throw httpError(400, "times invalidos. Use Brasil x Argentina.");
+  }
+
+  return {
+    homeTeam: teams[0],
+    awayTeam: teams[1],
+    startsAt: parseLocalDateTime(parts[1]),
+    competition: parts[2] || "Copa do Mundo"
+  };
+}
+
+function formatDateTime(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "sem data";
+  return date.toLocaleString("pt-BR", {
+    timeZone: "America/Sao_Paulo",
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+function formatMoney(value) {
+  return Number(value || 0).toLocaleString("pt-BR", {maximumFractionDigits: 0});
+}
+
+function buildPanelLink(gameId) {
+  const base = process.env.URL_BACKEND;
+  if (!base) return `/painel#bolao/${gameId}`;
+  const url = new URL("/painel", base);
+  url.hash = `bolao/${gameId}`;
+  return url.toString();
+}
+
+async function isBolaoAdmin(sender) {
+  return (await getOwnerLevelCached(sender)) >= 2;
+}
+
+async function assertBolaoAdmin(sender) {
+  if (!(await isBolaoAdmin(sender))) {
+    throw httpError(403, "somente dono real da Yuki pode gerenciar o bolao.");
+  }
+}
+
+async function findGame(ref) {
+  const raw = String(ref || "").trim();
+  if (!raw) throw httpError(400, "jogo ausente.");
+
+  const objectId = toObjectId(raw);
+  const query = objectId ? {$or: [{_id: objectId}, {code: raw}]} : {code: raw};
+  const game = await bolaoGames.findOne(query);
+  if (!game) throw httpError(404, "jogo nao encontrado.");
+  return game;
+}
+
+async function createGame(input, sender, options = {}) {
+  await assertBolaoAdmin(sender);
+
+  const startsAt = input.startsAt instanceof Date ? input.startsAt : parseLocalDateTime(input.startsAt);
+  const closesAt = input.closesAt ? new Date(input.closesAt) : new Date(startsAt.getTime() - DEFAULT_CLOSE_BEFORE_MS);
+  if (!options.testMode && closesAt.getTime() <= Date.now()) {
+    throw httpError(400, "o fechamento da aposta ja passou.");
+  }
+
+  const title = `${cleanText(input.homeTeam, "Time A")} x ${cleanText(input.awayTeam, "Time B")}`;
+  const code = `${slug(input.homeTeam)}-${slug(input.awayTeam)}-${crypto.randomBytes(2).toString("hex")}`;
+
+  return bolaoGames.create({
+    code,
+    title,
+    competition: cleanText(input.competition, "Copa do Mundo"),
+    homeTeam: cleanText(input.homeTeam, "Time A"),
+    awayTeam: cleanText(input.awayTeam, "Time B"),
+    startsAt,
+    closesAt,
+    status: "open",
+    createdBy: normalizeUserLid(sender),
+    groupId: input.groupId || null,
+    testMode: !!options.testMode,
+    minBet: Number(input.minBet || MIN_BET)
+  });
+}
+
+function serializeBet(bet) {
+  if (!bet) return null;
+  return {
+    id: String(bet._id),
+    gameId: String(bet.gameId),
+    gameCode: bet.gameCode,
+    userLid: bet.userLid,
+    name: bet.name,
+    groupId: bet.groupId,
+    homeScore: bet.homeScore,
+    awayScore: bet.awayScore,
+    score: `${bet.homeScore}x${bet.awayScore}`,
+    stake: bet.stake,
+    status: bet.status,
+    paidAmount: bet.paidAmount || 0,
+    placedAt: toIso(bet.placedAt),
+    updatedAt: toIso(bet.updatedAt)
+  };
+}
+
+function statusLabel(status) {
+  return {
+    open: "Aberto",
+    closed: "Fechado",
+    result_preview: "Resultado em preview",
+    paid: "Pago",
+    refunded: "Reembolsado",
+    cancelled: "Cancelado"
+  }[status] || status;
+}
+
+function serializeGame(game, extras = {}) {
+  const raw = typeof game.toObject === "function" ? game.toObject() : game;
+  const canBet = raw.status === "open" && new Date(raw.closesAt).getTime() > Date.now();
+  return {
+    id: String(raw._id),
+    code: raw.code,
+    title: raw.title,
+    competition: raw.competition,
+    homeTeam: raw.homeTeam,
+    awayTeam: raw.awayTeam,
+    startsAt: toIso(raw.startsAt),
+    closesAt: toIso(raw.closesAt),
+    status: raw.status,
+    statusLabel: statusLabel(raw.status),
+    canBet,
+    minBet: raw.minBet || MIN_BET,
+    publicLink: buildPanelLink(String(raw._id)),
+    result: raw.result?.homeScore !== null && raw.result?.awayScore !== null ? {
+      homeScore: raw.result.homeScore,
+      awayScore: raw.result.awayScore,
+      score: `${raw.result.homeScore}x${raw.result.awayScore}`,
+      setAt: toIso(raw.result.setAt)
+    } : null,
+    payoutPreview: raw.payoutPreview || {},
+    testMode: !!raw.testMode,
+    ...extras
+  };
+}
+
+async function getStats(gameIds) {
+  if (!gameIds.length) return new Map();
+  const rows = await bolaoBets.aggregate([
+    {$match: {gameId: {$in: gameIds}, status: "active"}},
+    {$group: {_id: "$gameId", pool: {$sum: "$stake"}, bets: {$sum: 1}}}
+  ]);
+  return new Map(rows.map((row) => [String(row._id), {pool: row.pool || 0, bets: row.bets || 0}]));
+}
+
+async function listPanelBolao(sender) {
+  const senderLid = normalizeUserLid(sender);
+  const since = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+  const games = await bolaoGames
+    .find({createdAt: {$gte: since}, status: {$ne: "cancelled"}})
+    .sort({startsAt: 1})
+    .limit(40)
+    .lean();
+
+  const ids = games.map((game) => game._id);
+  const [stats, userBets, user, canManage] = await Promise.all([
+    getStats(ids),
+    ids.length ? bolaoBets.find({gameId: {$in: ids}, userLid: senderLid}).lean() : [],
+    users.findOne({userLid: senderLid}).select("dinheiro").lean(),
+    isBolaoAdmin(senderLid)
+  ]);
+
+  const betMap = new Map(userBets.map((bet) => [String(bet.gameId), bet]));
+  return {
+    canManage,
+    balance: user?.dinheiro || 0,
+    games: games.map((game) => {
+      const id = String(game._id);
+      const stat = stats.get(id) || {pool: 0, bets: 0};
+      return serializeGame(game, {
+        pool: stat.pool,
+        bets: stat.bets,
+        userBet: serializeBet(betMap.get(id))
+      });
+    })
+  };
+}
+
+async function getPanelBolaoGame(sender, ref) {
+  const senderLid = normalizeUserLid(sender);
+  const game = await findGame(ref);
+  const gameId = game._id;
+  const [stats, userBet, canManage, activeBets] = await Promise.all([
+    getStats([gameId]),
+    bolaoBets.findOne({gameId, userLid: senderLid}).lean(),
+    isBolaoAdmin(senderLid),
+    bolaoBets.find({gameId, status: {$in: ["active", "paid", "lost", "refunded"]}})
+      .sort({paidAmount: -1, stake: -1})
+      .limit(60)
+      .lean()
+  ]);
+  const stat = stats.get(String(gameId)) || {pool: 0, bets: 0};
+  const showScores = canManage || game.status !== "open";
+
+  return {
+    canManage,
+    game: serializeGame(game, {
+      pool: stat.pool,
+      bets: stat.bets,
+      userBet: serializeBet(userBet)
+    }),
+    bets: activeBets.map((bet) => ({
+      name: bet.name,
+      stake: bet.stake,
+      score: showScores ? `${bet.homeScore}x${bet.awayScore}` : null,
+      status: bet.status,
+      paidAmount: bet.paidAmount || 0
+    }))
+  };
+}
+
+async function placeOrUpdateBet(input) {
+  const sender = normalizeUserLid(input.sender);
+  const game = await findGame(input.gameId || input.code);
+  if (game.status !== "open" || new Date(game.closesAt).getTime() <= Date.now()) {
+    throw httpError(409, "apostas fechadas para esse jogo.");
+  }
+
+  const score = normalizeScore(input.homeScore, input.awayScore);
+  const stake = Math.floor(Number(input.amount || input.stake || 0));
+  const minBet = Number(game.minBet || MIN_BET);
+  if (!Number.isFinite(stake) || stake < minBet) {
+    throw httpError(400, `aposta minima: ${minBet} moedas.`);
+  }
+
+  const user = await ensureUser(sender, input.name || "Sem nome");
+  const name = user?.name || input.name || "Sem nome";
+  const existing = await bolaoBets.findOne({gameId: game._id, userLid: sender}).lean();
+  if (existing && existing.status !== "active") throw httpError(409, "essa aposta ja foi encerrada.");
+
+  const previousStake = existing?.stake || 0;
+  const delta = stake - previousStake;
+  let balance = null;
+
+  if (delta > 0) {
+    balance = await updateUserAndCache(sender, {$inc: {dinheiro: -delta}}, {filter: {dinheiro: {$gte: delta}}, upsert: !existing, name});
+    if (!balance) throw httpError(402, "saldo insuficiente para essa aposta.");
+  }
+
+  if (delta < 0) {
+    balance = await updateUserAndCache(sender, {$inc: {dinheiro: Math.abs(delta)}}, {upsert: true, name});
+  }
+
+  try {
+    const bet = await bolaoBets.findOneAndUpdate(
+      {gameId: game._id, userLid: sender},
+      {
+        $set: {
+          gameCode: game.code,
+          name,
+          groupId: input.groupId || existing?.groupId || null,
+          homeScore: score.home,
+          awayScore: score.away,
+          stake,
+          status: "active",
+          updatedAt: new Date()
+        },
+        $setOnInsert: {placedAt: new Date()},
+        $inc: {revision: 1}
+      },
+      {new: true, upsert: true, setDefaultsOnInsert: true}
+    );
+
+    if (delta !== 0) {
+      await bolaoLedgers.create({
+        transactionId: `stake:${game._id}:${sender}:${bet.revision}:${Date.now()}`,
+        gameId: game._id,
+        gameCode: game.code,
+        userLid: sender,
+        type: delta > 0 ? "stake" : "stake_adjust",
+        amount: -delta,
+        meta: {previousStake, stake, score}
+      });
+    }
+
+    return {bet: serializeBet(bet), balance: balance?.dinheiro ?? null, game: serializeGame(game)};
+  } catch (err) {
+    if (delta > 0) await updateUserAndCache(sender, {$inc: {dinheiro: delta}}, {upsert: true, name});
+    throw err;
+  }
+}
+
+async function closeGame(ref, sender) {
+  await assertBolaoAdmin(sender);
+  const game = await findGame(ref);
+  if (game.status !== "open") throw httpError(409, "esse jogo nao esta aberto.");
+  game.status = "closed";
+  await game.save();
+  return serializeGame(game);
+}
+
+function buildPayout(activeBets, score) {
+  const pool = activeBets.reduce((sum, bet) => sum + Number(bet.stake || 0), 0);
+  const winners = activeBets.filter((bet) => bet.homeScore === score.home && bet.awayScore === score.away);
+
+  if (!winners.length) {
+    return {
+      pool,
+      totalBets: activeBets.length,
+      winnerCount: 0,
+      totalPayout: pool,
+      winners: [],
+      refunds: activeBets.map((bet) => ({
+        userLid: bet.userLid,
+        name: bet.name,
+        stake: bet.stake,
+        score: `${bet.homeScore}x${bet.awayScore}`,
+        total: bet.stake
+      }))
+    };
+  }
+
+  const winnerStake = winners.reduce((sum, bet) => sum + Number(bet.stake || 0), 0);
+  const rows = winners.map((bet) => ({
+    userLid: bet.userLid,
+    name: bet.name,
+    stake: bet.stake,
+    score: `${bet.homeScore}x${bet.awayScore}`,
+    poolShare: Math.floor((pool * bet.stake) / winnerStake),
+    bonus: bet.stake,
+    total: 0
+  }));
+
+  let remainder = pool - rows.reduce((sum, row) => sum + row.poolShare, 0);
+  for (let index = 0; remainder > 0 && rows.length; index = (index + 1) % rows.length) {
+    rows[index].poolShare += 1;
+    remainder -= 1;
+  }
+
+  for (const row of rows) row.total = row.poolShare + row.bonus;
+
+  return {
+    pool,
+    totalBets: activeBets.length,
+    winnerCount: rows.length,
+    totalPayout: rows.reduce((sum, row) => sum + row.total, 0),
+    winners: rows,
+    refunds: []
+  };
+}
+
+async function createResultPreview(ref, sender, scoreInput) {
+  await assertBolaoAdmin(sender);
+  const game = await findGame(ref);
+  if (!["closed", "result_preview"].includes(game.status)) {
+    throw httpError(409, "feche o jogo antes de inserir resultado.");
+  }
+
+  const score = typeof scoreInput === "string"
+    ? parseScoreText(scoreInput)
+    : normalizeScore(scoreInput.homeScore ?? scoreInput.home, scoreInput.awayScore ?? scoreInput.away);
+  const activeBets = await bolaoBets.find({gameId: game._id, status: "active"}).lean();
+  const preview = buildPayout(activeBets, score);
+
+  game.result = {homeScore: score.home, awayScore: score.away, setBy: normalizeUserLid(sender), setAt: new Date()};
+  game.payoutPreview = {...preview, generatedAt: new Date()};
+  game.status = "result_preview";
+  await game.save();
+  return serializeGame(game, {pool: preview.pool, bets: preview.totalBets});
+}
+
+async function applyCreditOnce({transactionId, game, userLid, name, type, amount, meta}) {
+  const inserted = await bolaoLedgers.updateOne(
+    {transactionId},
+    {$setOnInsert: {
+      transactionId,
+      gameId: game._id,
+      gameCode: game.code,
+      userLid,
+      type,
+      amount,
+      status: "applied",
+      meta: meta || {},
+      createdAt: new Date()
+    }},
+    {upsert: true}
+  );
+
+  if (inserted.upsertedCount > 0) {
+    await updateUserAndCache(userLid, {$inc: {dinheiro: amount}}, {upsert: true, name});
+    return true;
+  }
+  return false;
+}
+
+async function confirmPayout(ref, sender) {
+  await assertBolaoAdmin(sender);
+  const game = await findGame(ref);
+  if (["paid", "refunded"].includes(game.status)) return serializeGame(game);
+  if (game.status !== "result_preview") throw httpError(409, "gere o preview do resultado antes.");
+
+  const activeBets = await bolaoBets.find({gameId: game._id, status: "active"}).lean();
+  const winners = new Map((game.payoutPreview?.winners || []).map((winner) => [winner.userLid, winner]));
+
+  if (!activeBets.length || !winners.size) {
+    for (const bet of activeBets) {
+      await applyCreditOnce({
+        transactionId: `refund:${game._id}:${bet.userLid}`,
+        game,
+        userLid: bet.userLid,
+        name: bet.name,
+        type: "refund",
+        amount: bet.stake,
+        meta: {reason: "no_winners"}
+      });
+      await bolaoBets.updateOne({_id: bet._id, status: "active"}, {$set: {status: "refunded", paidAmount: bet.stake, updatedAt: new Date()}});
+    }
+    game.status = "refunded";
+    game.paidAt = new Date();
+    await game.save();
+    return serializeGame(game);
+  }
+
+  for (const bet of activeBets) {
+    const winner = winners.get(bet.userLid);
+    if (winner) {
+      await applyCreditOnce({
+        transactionId: `payout:${game._id}:${bet.userLid}`,
+        game,
+        userLid: bet.userLid,
+        name: bet.name,
+        type: "payout",
+        amount: winner.total,
+        meta: {poolShare: winner.poolShare, bonus: winner.bonus}
+      });
+      await bolaoBets.updateOne({_id: bet._id, status: "active"}, {$set: {status: "paid", paidAmount: winner.total, updatedAt: new Date()}});
+    } else {
+      await bolaoBets.updateOne({_id: bet._id, status: "active"}, {$set: {status: "lost", paidAmount: 0, updatedAt: new Date()}});
+    }
+  }
+
+  game.status = "paid";
+  game.paidAt = new Date();
+  await game.save();
+  return serializeGame(game);
+}
+
+async function cancelGame(ref, sender, reason = "cancelado pelo dono") {
+  await assertBolaoAdmin(sender);
+  const game = await findGame(ref);
+  if (["paid", "refunded", "cancelled"].includes(game.status)) throw httpError(409, "esse jogo ja foi encerrado.");
+
+  const activeBets = await bolaoBets.find({gameId: game._id, status: "active"}).lean();
+  for (const bet of activeBets) {
+    await applyCreditOnce({
+      transactionId: `cancel:${game._id}:${bet.userLid}`,
+      game,
+      userLid: bet.userLid,
+      name: bet.name,
+      type: "cancel_refund",
+      amount: bet.stake,
+      meta: {reason}
+    });
+    await bolaoBets.updateOne({_id: bet._id, status: "active"}, {$set: {status: "cancelled", paidAmount: bet.stake, updatedAt: new Date()}});
+  }
+
+  game.status = "cancelled";
+  game.cancelReason = reason;
+  game.cancelledAt = new Date();
+  await game.save();
+  return {game: serializeGame(game), refunded: activeBets.length};
+}
+
+function buildGroupAnnouncement(game) {
+  return `*Bolao da Yuki*
+
+${game.title}
+Jogo: ${formatDateTime(game.startsAt)}
+Fecha: ${formatDateTime(game.closesAt)}
+
+Placar exato. Minimo: ${game.minBet || MIN_BET} moedas.
+Premio: pool dividido entre quem cravar + bonus igual ao valor apostado.
+
+Painel: ${buildPanelLink(String(game._id))}
+Comando: ${prefixo || "/"}bolao apostar ${game.code} 2x1 ${game.minBet || MIN_BET}`;
+}
+
+async function announceGame(sock, ref, groupId, sender) {
+  await assertBolaoAdmin(sender);
+  if (!groupId?.endsWith("@g.us")) throw httpError(400, "anuncie dentro de um grupo.");
+  const game = await findGame(ref);
+  const text = buildGroupAnnouncement(game);
+  await sock.sendMessage(groupId, {text});
+  return serializeGame(game);
+}
+
+module.exports = {
+  announceGame,
+  buildGroupAnnouncement,
+  buildPanelLink,
+  cancelGame,
+  closeGame,
+  confirmPayout,
+  createGame,
+  createResultPreview,
+  findGame,
+  formatDateTime,
+  formatMoney,
+  httpError,
+  isBolaoAdmin,
+  listPanelBolao,
+  getPanelBolaoGame,
+  parseGameCreateText,
+  parseScoreText,
+  placeOrUpdateBet,
+  serializeGame
+};


### PR DESCRIPTION
## Resumo
- reseta a branch do bolao em cima da main atual
- remove o worker/reconciler automatico que podia disputar o socket no boot
- recria o bolao em fluxo manual e seguro: criar, anunciar, apostar, fechar, resultado e pagar
- adiciona aba Bolao no painel com aposta protegida por cookie + CSRF
- corrige submit do painel para usar o form real do evento

## Testes
- node --check nos arquivos JS alterados
- require smoke dos modulos e comandos novos
- loader recursivo de comandos carregou 105 comandos incluindo bolao/testebolao
- smoke de funcoes puras do bolao
- smoke visual desktop/mobile em mock local do painel, com aposta salva e sem overflow lateral