### PR TITLE
feat(yuki): adiciono modo pessoal de teste

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 node_modules/
 .env
 auth/
+src/assets/auth/
+src/assets/auth-lenoz/
 temp/
 *.log
+personal-mode*.log
 src/api/tiktok-api/venv/
 src/api/tiktok-api/**/__pycache__/
 src/api/tiktok-api/**/*.py[cod]

--- a/src/commands/geral/disableai.js
+++ b/src/commands/geral/disableai.js
@@ -1,0 +1,19 @@
+const { isPersonalMode, setPersonalAiEnabled } = require("../../utils/personalMode");
+
+module.exports = {
+  name: "disableai",
+  categoria: "padrao",
+  async execute(sock, msg, from) {
+    if (!isPersonalMode()) {
+      await sock.sendMessage(from, { text: "Esse comando so funciona no modo pessoal." }, { quoted: msg });
+      return;
+    }
+
+    const saved = await setPersonalAiEnabled(from, false);
+    await sock.sendMessage(from, {
+      text: saved
+        ? "IA desligada nesse chat. Modo quietinho de novo."
+        : "Nao consegui salvar isso no Redis agora."
+    }, { quoted: msg });
+  }
+};

--- a/src/commands/geral/enableai.js
+++ b/src/commands/geral/enableai.js
@@ -1,0 +1,19 @@
+const { isPersonalMode, setPersonalAiEnabled } = require("../../utils/personalMode");
+
+module.exports = {
+  name: "enableai",
+  categoria: "padrao",
+  async execute(sock, msg, from) {
+    if (!isPersonalMode()) {
+      await sock.sendMessage(from, { text: "Esse comando so funciona no modo pessoal." }, { quoted: msg });
+      return;
+    }
+
+    const saved = await setPersonalAiEnabled(from, true);
+    await sock.sendMessage(from, {
+      text: saved
+        ? "IA liberada nesse chat. Vou responder so quando fizer sentido."
+        : "Nao consegui salvar isso no Redis agora."
+    }, { quoted: msg });
+  }
+};

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@ require("dotenv").config({quiet: true});
 const { normalizeUserLid } = require("./utils/normalizeUserLid");
 
 //Prefixo da bot
-const prefixo = process.env.PREFIXO
+const prefixo = process.env.PREFIXO || "/"
 
 //Nome do bot
 const botName = "Yuki"
@@ -13,8 +13,9 @@ const version = "4.5.3"
 //Lids dos donos
 const ownerLids = [
   normalizeUserLid(process.env.SPEED_LID) || "188123996786820@lid",
-  normalizeUserLid(process.env.LENOZ_LID) || "221856653123760@lid"
-];
+  normalizeUserLid(process.env.LENOZ_LID) || "221856653123760@lid",
+  normalizeUserLid(process.env.YUKI_PERSONAL_NUMBER)
+].filter(Boolean);
 
 const numberOwner = ownerLids[0];
 

--- a/src/events/messages.js
+++ b/src/events/messages.js
@@ -22,6 +22,13 @@ const { isBotBanned } = require("../utils/botBan");
 const { resolveOwnerDuel } = require("../utils/ownerLuck");
 const normalizeCommandKey = require("../utils/commandKey");
 const { buildCommandCatalog, findRelevantCommandContext } = require("../utils/commandCatalog");
+const {
+  getPersonalSender,
+  isExplicitCommand,
+  isPersonalActor,
+  isPersonalAiEnabled,
+  isPersonalMode
+} = require("../utils/personalMode");
 const { groupCache, muteCache, ownerCache, userCache } = require("../utils/hotPathCache");
 const {
   createMessageMongoMetrics,
@@ -455,6 +462,8 @@ async function safeRedis(action, fallback = null) {
     }
 
     async function scheduleSilentReply({ sock, from }) {
+      if (isPersonalMode()) return;
+
       if (activeInterval.has(from)) {
         clearTimeout(activeInterval.get(from));
       }
@@ -534,8 +543,11 @@ async function safeRedis(action, fallback = null) {
         }
     }
 
-    async function maybeHandleAiReply({ sock, msg, from, sender, body, groupReply }) {
-      if (!groupReply?.autoReply || !from.endsWith("@g.us")) return false;
+    async function maybeHandleAiReply({ sock, msg, from, sender, body, groupReply, forcePersonal = false }) {
+      const personalMode = isPersonalMode();
+      const regularGroupAi = groupReply?.autoReply && from.endsWith("@g.us");
+      if (personalMode && !forcePersonal) return false;
+      if (!personalMode && !regularGroupAi) return false;
 
       const groupPrefix = groupReply?.configs?.prefixo || prefixo;
       const trackContext = shouldTrackAiContext(body, groupPrefix);
@@ -619,6 +631,15 @@ async function safeRedis(action, fallback = null) {
 module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
   yukiIA.setCommandCatalog(buildCommandCatalog(commandsMap));
 
+  function getMessageBody(msg) {
+    return (msg?.message?.conversation) ||
+      (msg?.message?.extendedTextMessage?.text) ||
+      (msg?.message?.imageMessage?.caption) ||
+      (msg?.message?.documentMessage?.caption) ||
+      msg?.message?.buttonsResponseMessage?.selectedButtonId ||
+      "";
+  }
+
   function relevantCommandContext(body, recent = []) {
     return findRelevantCommandContext(commandsMap, [
       body,
@@ -627,11 +648,19 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
   }
 
   sock.ev.on("messages.upsert", async (m) => {
-    const msg = m?.messages?.[0];
+    const personalMode = isPersonalMode();
+    const messages = Array.isArray(m?.messages) ? m.messages : [];
+    const msg = personalMode
+      ? messages.find((candidate) => isExplicitCommand(getMessageBody(candidate), prefixo)) ||
+        messages.find((candidate) => candidate?.key?.fromMe) ||
+        messages[0]
+      : messages[0];
     if (!msg?.key) return;
-    if (msg.key.fromMe) return
+    if (msg.key.fromMe && !personalMode) return;
+    const personalSender = personalMode ? getPersonalSender(sock) : null;
     
     const senderRaw =
+      (personalMode && msg.key.fromMe ? personalSender : null) ||
       msg?.key?.participantLid ||
       msg?.key?.senderLid ||
       msg?.key?.participant ||
@@ -642,6 +671,60 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     const from = msg?.key?.remoteJid || msg?.key?.participantLid
     if (!from || !sender) return;
 
+    const bot = new YukiBot({sock: sock, msg});
+    const body = getMessageBody(msg) || "Msg estranha...";
+    const bodyCase = body.toLowerCase();
+
+    //argumentos
+    const args = body.slice(prefixo.length).trim().split(/ +/);
+    const isPrefixCommand = body.startsWith(prefixo);
+    const isExplicitPersonalCommand = isExplicitCommand(body, prefixo);
+    const noPrefixPreview = isPrefixCommand ? [] : body.trim().split(/ +/);
+    const noPrefixCommandName = normalizeCommandKey(noPrefixPreview[0]);
+    const noPrefixCommandCandidate = noPrefixCommandName ? commandsMap.get(noPrefixCommandName) : null;
+    const personalActor = personalMode ? isPersonalActor({ msg, sender, sock }) : false;
+
+    if (personalMode) {
+      if (!personalActor) return;
+
+      if (!isExplicitPersonalCommand) {
+        if (await isPersonalAiEnabled(from)) {
+          await maybeHandleAiReply({
+            sock,
+            msg,
+            from,
+            sender,
+            body,
+            groupReply: { autoReply: true, configs: { prefixo } },
+            forcePersonal: true
+          });
+        }
+        return;
+      }
+
+      if (isPrefixCommand) {
+        const personalArgs = body.slice(prefixo.length).trim().split(/ +/);
+        const personalCommandName = normalizeCommandKey(personalArgs.shift());
+        const personalCommand = commandsMap.get(personalCommandName);
+
+        console.log(`[personal-mode] comando direto: /${personalCommandName || ""} existe=${!!personalCommand}`);
+
+        if (!personalCommand) {
+          await sock.sendMessage(from, { text: `Comando nao encontrado: ${prefixo}${personalCommandName || ""}` });
+          return;
+        }
+
+        try {
+          await personalCommand.execute(sock, msg, from, personalArgs, erros_prontos, espera_pronta, bot, sender);
+          console.log(`[personal-mode] /${personalCommandName} finalizado`);
+        } catch (err) {
+          console.error(`[personal-mode] erro em /${personalCommandName}:`, err);
+          await sock.sendMessage(from, { text: erros_prontos });
+        }
+        return;
+      }
+    }
+
     const mongoMetrics = createMessageMongoMetrics({ from, sender });
 
     try {
@@ -649,7 +732,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
     
     
-    if(process.env.DEV_AMBIENT === "true" && from !== '120363424415515445@g.us') return;
+    if(!personalMode && process.env.DEV_AMBIENT === "true" && from !== '120363424415515445@g.us') return;
     //console.log(msg)
 //escopo pra Nao vazar variaveis
      {
@@ -672,7 +755,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     }
     //ignora mensagens de si mesmo
     if(process.env.DEV_AMBIENT === "false") {
-    if (msg.key.fromMe) return
+    if (msg.key.fromMe && !personalMode) return
       
     }
     
@@ -687,7 +770,6 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
 
     
 
-    const bot = new YukiBot({sock: sock, msg});
     const isGroup = from.endsWith("@g.us");
     const isPrivate = from.endsWith("@lid");
     let ownerPromise = null;
@@ -696,20 +778,6 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       if (!ownerPromise) ownerPromise = getCachedOwner(sender, mongoMetrics);
       return ownerPromise;
     };
-
-    const body = (msg.message?.conversation) ||
-    (msg.message?.extendedTextMessage?.text) ||
-    (msg.message?.imageMessage?.caption) ||
-    (msg.message?.documentMessage?.caption) || msg?.message?.buttonsResponseMessage?.selectedButtonId || "Msg estranha...";
-
-    const bodyCase = body.toLowerCase();
-
-    //argumentos
-    const args = body.slice(prefixo.length).trim().split(/ +/);
-    const isPrefixCommand = body.startsWith(prefixo);
-    const noPrefixPreview = isPrefixCommand ? [] : body.trim().split(/ +/);
-    const noPrefixCommandName = normalizeCommandKey(noPrefixPreview[0]);
-    const noPrefixCommandCandidate = noPrefixCommandName ? commandsMap.get(noPrefixCommandName) : null;
 
     let usersSender = null;
     let userLoaded = false;
@@ -737,7 +805,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
 
     //Se uma mensagem Nao vier de um grupo entao ele pausa os comandos
-    if(isPrivate) {
+    if(!personalMode && isPrivate) {
       const privateUser = await getUsersSender();
       const Notvip = !privateUser?.vencimentoVip || Date.now() > privateUser?.vencimentoVip?.getTime();
 
@@ -802,12 +870,14 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       
     }
     
-    queueMessageActivity(sender, from);
-    markQueuedWrite(mongoMetrics);
+    if (!personalMode) {
+      queueMessageActivity(sender, from);
+      markQueuedWrite(mongoMetrics);
+    }
 
      //se estiver alguem mutado
     let userMutado = null;
-    if(isGroup) {
+    if(!personalMode && isGroup) {
       const cachedMute = muteCache.get(muteCacheKey(sender, from));
       if(cachedMute !== undefined) {
         userMutado = cachedMute;
@@ -857,9 +927,12 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       return
     }
     
-    addXp(sender, 1, sock, from, msg);
-    markQueuedWrite(mongoMetrics);
+    if (!personalMode) {
+      addXp(sender, 1, sock, from, msg);
+      markQueuedWrite(mongoMetrics);
+    }
 
+    if (!personalMode) {
     //Caso tenha um aluguel a pagar
     const alugarExiste = await safeRedis(() => clientRedis.exists(`aluguel:${sender}&${from}`), 0);
     
@@ -1025,6 +1098,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       await safeRedis(() => clientRedis.del(`namoro:${sender}`));
     }
   }
+    }
 
     
   
@@ -1032,7 +1106,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
   const groupReply = groupDBInfo;
   
   //Caso o grupo tenha a anttotag ativa
-  if(from.endsWith("@g.us") && groupReply?.antiTotag) {
+  if(!personalMode && from.endsWith("@g.us") && groupReply?.antiTotag) {
     if(msg.key.fromMe) return;
     try {
       //pega info do grupo
@@ -1057,7 +1131,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
   }
   
   //Caso tenha o antilink ativo
-  if(groupReply?.configs?.antlink && (bodyCase.includes("https://") || bodyCase.includes("http://"))) {
+  if(!personalMode && groupReply?.configs?.antlink && (bodyCase.includes("https://") || bodyCase.includes("http://"))) {
     try {
       
       const metadata = await sock.groupMetadata(from);
@@ -1100,7 +1174,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
     
   }
   //caso o grupo tenha autoreply ativo
-  if(groupReply?.autoReply && from.endsWith("@g.us")) {
+  if(!personalMode && groupReply?.autoReply && from.endsWith("@g.us")) {
 
     //geração de texto
     await maybeHandleAiReply({ sock, msg, from, sender, body, groupReply });
@@ -1110,7 +1184,7 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
       //Caso um grupo tenha auto download
   const groupDonwload = groupDBInfo;
   
-  if((groupDonwload && groupDonwload.autoDownload) || from.endsWith("@lid")) {
+  if(!personalMode && ((groupDonwload && groupDonwload.autoDownload) || from.endsWith("@lid"))) {
   if(body.includes("https://open.spotify.com/track/")) {
     spotifyDl(sock, msg, from, body, erros_prontos, espera_pronta, bot)
   }
@@ -1140,9 +1214,9 @@ module.exports = (sock, commandsMap, erros_prontos, espera_pronta) => {
         //marca como false
         flagMessage.set(grupoRemote, false);
       }
-    
+
     //Caso o users tenha o modo sem prefixo
-if(noPrefixCommandCandidate && !isPrefixCommand) {
+if(!personalMode && noPrefixCommandCandidate && !isPrefixCommand) {
   const noPrefixUser = await getUsersSender();
 
   if(!noPrefixUser?.prefixo) {
@@ -1240,6 +1314,9 @@ if(noPrefixCommandCandidate && !isPrefixCommand) {
   const commandName = normalizeCommandKey(args.shift());
   //procura no map
   const commandGet = commandsMap.get(commandName)
+  if (personalMode) {
+    console.log(`[personal-mode] comando detectado: /${commandName || ""} existe=${!!commandGet}`);
+  }
 
 //se nao existir
     if (!commandGet) {
@@ -1313,10 +1390,9 @@ if(noPrefixCommandCandidate && !isPrefixCommand) {
       return
     }
     
-              //lida com aluguel
-    const commandUser = await getUsersSender();
     const isPadrao = commandGet.categoria === "padrao";
-    if(!isPadrao && from.endsWith("@g.us") && process.env.DEV_AMBIENT === "false") {
+    if(!personalMode && !isPadrao && from.endsWith("@g.us") && process.env.DEV_AMBIENT === "false") {
+    const commandUser = await getUsersSender();
     const grupoAluguel = groupDBInfo;
     
     if(!grupoAluguel) return;
@@ -1337,21 +1413,36 @@ if(noPrefixCommandCandidate && !isPrefixCommand) {
     }
     
     
+    if (personalMode) {
+      console.log(`[personal-mode] executando /${commandName} em ${from} sender=${sender}`);
+    }
+
     //Simula escrita
-    await sock.sendPresenceUpdate('composing', from);
+    if (!personalMode) {
+      await sock.sendPresenceUpdate('composing', from);
+    }
     
     //executa o comando
     await commandGet.execute(sock, msg, from, args, erros_prontos, espera_pronta, bot, sender);
+    if (personalMode) {
+      console.log(`[personal-mode] /${commandName} finalizado`);
+    }
     
     //pausa a simulacao
-    await sock.sendPresenceUpdate('paused', from);
+    if (!personalMode) {
+      await sock.sendPresenceUpdate('paused', from);
+    }
 //adiciona no contador de comandos
-    queueCommandActivity(sender, from);
-    markQueuedWrite(mongoMetrics, 3);
+    if (!personalMode) {
+      queueCommandActivity(sender, from);
+      markQueuedWrite(mongoMetrics, 3);
+    }
    
      //Adiciona nas metricas
-  await safeRedis(() => clientRedis.incr("metrics:commands:min"));
-  await safeRedis(() => clientRedis.expire("metrics:commands:min", 60));
+  if (!personalMode) {
+    await safeRedis(() => clientRedis.incr("metrics:commands:min"));
+    await safeRedis(() => clientRedis.expire("metrics:commands:min", 60));
+  }
   }
     });
     

--- a/src/events/participantUp.js
+++ b/src/events/participantUp.js
@@ -1,10 +1,12 @@
 const { ensureGroup } = require("../utils/dbHelpers");
+const { isPersonalMode } = require("../utils/personalMode");
 
 
 
 module.exports = (sock) => {
   
   sock.ev.on("group-participants.update", async(update) => {
+    if (isPersonalMode()) return;
     
     console.log(update);
     

--- a/src/events/waifus.js
+++ b/src/events/waifus.js
@@ -1,9 +1,12 @@
 const { yukiEv } = require("../utils/events.js");
 const path = require("path");
+const { isPersonalMode } = require("../utils/personalMode");
 
 module.exports = (sock) => {
   
   yukiEv.on("waifu:acquired", async (ctx) => {
+    if (isPersonalMode()) return;
+
     console.log(ctx);
     
     if(process.env.DEV_AMBIENT === "true" && ctx.ctx.from !== '120363424415515445@g.us') return;

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const os = require("os");
 require("dotenv").config({ quiet: true });
 const server = require("./backend/server.js");
 const normalizeCommandKey = require("./utils/commandKey");
+const { getPersonalNumber, isPersonalMode } = require("./utils/personalMode");
 
 let isBooting = false;
 let reconnectTimeout = null;
@@ -59,6 +60,9 @@ loadCommands(path.join(__dirname, "commands"));
 console.log(`NOME: ${botName}
 COMANDOS: ${commandsMap.size}
 SISTEM: ${os.type()}`);
+if (isPersonalMode()) {
+  console.log(`[personal-mode] ativo para ${getPersonalNumber()}. Eventos passivos desligados.`);
+}
 
 const jsonErros = require("./database/erros.json");
 const erros_prontos = jsonErros[Math.floor(Math.random() * jsonErros.length)];
@@ -113,7 +117,9 @@ async function yukibot() {
       return;
     }
 
-    await redisConnect();
+    if (!isPersonalMode()) {
+      await redisConnect();
+    }
 
     const sock = await SockBot.init();
 
@@ -139,10 +145,14 @@ async function yukibot() {
       }
     });
 
-    server(sock);
+    if (!isPersonalMode()) {
+      server(sock);
+    }
     require("./events/messages.js")(sock, commandsMap, erros_prontos, espera_pronta);
-    require("./events/participantUp")(sock);
-    require("./events/waifus.js")(sock);
+    if (!isPersonalMode()) {
+      require("./events/participantUp")(sock);
+      require("./events/waifus.js")(sock);
+    }
   } catch (err) {
     console.error("Falha ao iniciar a Yuki:", err);
     scheduleReconnect("erro na inicializacao");

--- a/src/sock.js
+++ b/src/sock.js
@@ -1,6 +1,7 @@
 const { default: makeWASocket, useMultiFileAuthState, makeCacheableSignalKeyStore, requestPairingCode, baileys, fetchLatestBaileysVersion, Browsers} = require("whaileys");
 const P = require("pino");
 const path = require("path");
+const { isPersonalMode, resolveAuthDir } = require("./utils/personalMode");
 require("dotenv").config();
 
 class SockBot {
@@ -10,7 +11,11 @@ class SockBot {
         this.QRcode = QRcode
     }
     async init() {
-        const { state, saveCreds } = await useMultiFileAuthState(path.join(__dirname, "/assets/auth"));
+        const authDir = resolveAuthDir(__dirname);
+        if (isPersonalMode()) {
+            console.log(`[personal-mode] usando auth isolada em: ${authDir}`);
+        }
+        const { state, saveCreds } = await useMultiFileAuthState(authDir);
   
   //Pega a ultima versao da baileys 
   const { version } = await fetchLatestBaileysVersion();

--- a/src/utils/personalMode.js
+++ b/src/utils/personalMode.js
@@ -1,0 +1,94 @@
+const path = require("path");
+const { clientRedis } = require("../lib/redis");
+const { normalizeUserLid } = require("./normalizeUserLid");
+
+const PERSONAL_AI_PREFIX = "personal-mode:ai:";
+
+function isEnabledValue(value) {
+  return ["1", "true", "yes", "on"].includes(String(value || "").trim().toLowerCase());
+}
+
+function isPersonalMode() {
+  return isEnabledValue(process.env.YUKI_PERSONAL_MODE);
+}
+
+function getPersonalNumber() {
+  return String(process.env.YUKI_PERSONAL_NUMBER || process.env.NUMBER || "5561983056421")
+    .replace(/\D/g, "");
+}
+
+function resolveAuthDir(baseDir) {
+  const configured = process.env.YUKI_AUTH_DIR || "assets/auth";
+  return path.isAbsolute(configured) ? configured : path.join(baseDir, configured);
+}
+
+function getPersonalSender(sock) {
+  const number = getPersonalNumber();
+  const candidates = [
+    process.env.YUKI_PERSONAL_LID,
+    process.env.LENOZ_LID,
+    sock?.user?.lid,
+    sock?.user?.id,
+    number ? `${number}@s.whatsapp.net` : null
+  ];
+
+  for (const candidate of candidates) {
+    const normalized = normalizeUserLid(candidate);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
+function isPersonalActor({ msg, sender, sock }) {
+  if (!isPersonalMode()) return false;
+  if (msg?.key?.fromMe) return true;
+
+  const normalizedSender = normalizeUserLid(sender);
+  const allowed = [
+    getPersonalSender(sock),
+    normalizeUserLid(process.env.YUKI_PERSONAL_LID),
+    normalizeUserLid(process.env.LENOZ_LID),
+    normalizeUserLid(`${getPersonalNumber()}@s.whatsapp.net`)
+  ].filter(Boolean);
+
+  return !!normalizedSender && allowed.includes(normalizedSender);
+}
+
+function isExplicitCommand(body, prefixo) {
+  const text = String(body || "").trim();
+  const prefix = prefixo || "/";
+  return text.startsWith(prefix) || text.startsWith(">");
+}
+
+function personalAiKey(chatId) {
+  return `${PERSONAL_AI_PREFIX}${chatId}`;
+}
+
+async function isPersonalAiEnabled(chatId) {
+  if (!isPersonalMode() || !chatId || !clientRedis?.isOpen) return false;
+  return (await clientRedis.exists(personalAiKey(chatId))) === 1;
+}
+
+async function setPersonalAiEnabled(chatId, enabled) {
+  if (!isPersonalMode() || !chatId || !clientRedis?.isOpen) return false;
+
+  if (enabled) {
+    await clientRedis.set(personalAiKey(chatId), "1");
+    return true;
+  }
+
+  await clientRedis.del(personalAiKey(chatId));
+  return true;
+}
+
+module.exports = {
+  getPersonalNumber,
+  getPersonalSender,
+  isExplicitCommand,
+  isPersonalActor,
+  isPersonalAiEnabled,
+  isPersonalMode,
+  resolveAuthDir,
+  setPersonalAiEnabled
+};

--- a/yuki-lenoz-start.bat
+++ b/yuki-lenoz-start.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+
+set YUKI_PERSONAL_MODE=true
+set YUKI_PERSONAL_NUMBER=5561983056421
+set NUMBER=5561983056421
+set PREFIXO=/
+set YUKI_AUTH_DIR=assets/auth-lenoz
+
+echo.
+echo Yuki modo pessoal do Lenoz
+echo Numero: %YUKI_PERSONAL_NUMBER%
+echo Auth: src\%YUKI_AUTH_DIR%
+echo Passivos: desligados
+echo IA: desligada por padrao, use /enableai no chat
+echo.
+
+node src\index.js
+
+echo.
+echo Yuki encerrou.
+pause


### PR DESCRIPTION
criei um modo pessoal/local pra testar feature nova da yuki sem precisar jogar direto na host/main.

por que isso existe:
- quando eu preciso testar coisa nova no meu numero, hoje eu acabo tendo que subir pra host ou mexer na main;
- se der ruim, fica aquela novela de resetar commit, voltar main, arrumar deploy etc;
- esse modo deixa eu validar comando real no WhatsApp antes de mandar pra producao.

como funciona:
- `yuki-lenoz-start.bat` sobe a yuki com `YUKI_PERSONAL_MODE=true`;
- usa auth separada em `src/assets/auth-lenoz`, entao nao mistura com a sessao normal da yuki;
- permite comando `fromMe`, pra eu conseguir mandar `/ping`, `/sticker`, `/play` etc pelo meu proprio WhatsApp;
- desliga passivos no modo pessoal: welcome/bye, waifu event, XP/level, anti-link, anti-totag, auto-download, resposta pendente, modo sem prefixo e backend/redis;
- IA fica desligada por padrao e so liga por chat com `/enableai`; `/disableai` desliga de novo.

seguranca/isolamento:
- sem `YUKI_PERSONAL_MODE=true`, o fluxo normal continua igual;
- `src/assets/auth/`, `src/assets/auth-lenoz/` e logs locais ficam no `.gitignore`;
- nao entra token, sessao, `.env`, log ou auth no commit;
- isso e pra teste local, nao pra rodar na host.

teste que fiz:
- rodei o `.bat` local;
- `/ptest` temporario confirmou o fluxo e foi removido antes do commit;
- `/ping` respondeu no grupo;
- `node --check` passou nos arquivos alterados;
- smoke local do handler com `/meulid` passou.